### PR TITLE
Run coverage jobs from root level directory

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
     - run: npm install
-    - run: npm run coverage --workspace=packages/rtcstats-shared
+    - run: node_modules/.bin/c8 --reporter html --reporter lcov node_modules/.bin/mocha packages/rtcstats-shared/test
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
       with:
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
     - run: npm install
-    - run: npm run coverage --workspace=packages/rtcstats-server
+    - run: NODE_CONFIG_DIR=packages/rtcstats-server/config node_modules/.bin/c8 --reporter html --reporter lcov node_modules/.bin/mocha packages/rtcstats-server/test
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
       with:


### PR DESCRIPTION
avoiding path issues from npm workspaces
