### PR TITLE
remove special casing of full connection close for metadata handling

### DIFF
--- a/packages/rtcstats-shared/dump.js
+++ b/packages/rtcstats-shared/dump.js
@@ -73,16 +73,14 @@ export async function readRTCStatsDump(blob) {
             extra,
         });
 
-        if (!(connection_id === null && method === 'close')) {
-            if (!data.eventSizes[connection_id]) {
-                data.eventSizes[connection_id] = [];
-            }
-            data.eventSizes[connection_id].push({
-                x: lastTime,
-                y: line.length,
-                method,
-            });
+        if (!data.eventSizes[connection_id]) {
+            data.eventSizes[connection_id] = [];
         }
+        data.eventSizes[connection_id].push({
+            x: lastTime,
+            y: line.length,
+            method,
+        });
     }
     return data;
 }

--- a/packages/rtcstats-shared/test/dump.js
+++ b/packages/rtcstats-shared/test/dump.js
@@ -34,7 +34,13 @@ describe('RTCStats dump', () => {
                     type: 'close',
                     value: 1001
                 }]},
-                eventSizes: {},
+                eventSizes: {
+                    null: [{
+                        method: 'close',
+                        x: 1,
+                        y: 21,
+                    }],
+                },
             });
         });
 


### PR DESCRIPTION
ignoring it was probably an artifact of the wrong timestamp