### PR TITLE
js: add cpuPerformance to metadata

### DIFF
--- a/packages/rtcstats-js/trace-websocket.js
+++ b/packages/rtcstats-js/trace-websocket.js
@@ -44,7 +44,6 @@ export function WebSocketTrace(config = {}) {
             buffer.push(args);
         }
     };
-
     trace.close = () => {
         if (window.sessionStorage && config.countReloads) {
             // A clean disconnect clears the reload count.
@@ -66,6 +65,7 @@ export function WebSocketTrace(config = {}) {
             hardwareConcurrency: navigator.hardwareConcurrency,
             userAgentData: navigator.userAgentData,
             deviceMemory: navigator.deviceMemory,
+            cpuPerformance: navigator.cpuPerformance,
             screen: {
                 width: window.screen.availWidth,
                 height: window.screen.availHeight,


### PR DESCRIPTION
currently still behind flag in Chrome:
  https://wicg.github.io/cpu-performance/

(waiting until this is launched in Chrome)