### PR TITLE
shared: workaround webrtc-internals dump format timeseries woes

### DIFF
--- a/packages/rtcstats-shared/test/timeseries.js
+++ b/packages/rtcstats-shared/test/timeseries.js
@@ -36,6 +36,30 @@ describe('timeseries', () => {
                 },
             });
         });
+        it('handles series with different starting points', () => {
+            const input = {
+                'a-frameHeight': {
+                    endTime: '2025-09-25T10:04:24.377Z',
+                    startTime: '2025-09-25T10:04:18.088Z',
+                    statsType: 'outbound-rtp',
+                    values: '[640]',
+                },
+                'a-timestamp': {
+                    endTime: '2025-09-25T10:04:24.377Z',
+                    startTime: '2025-09-25T10:04:18.088Z',
+                    statsType: 'outbound-rtp',
+                    values: '[0, 1]',
+                },
+            };
+            const result = createInternalsTimeSeries({stats: input});
+            expect(result).to.deep.equal({
+                a: {
+                    type: 'outbound-rtp',
+                    frameHeight: [[1, 640]],
+                    timestamp: [[0, 0], [1, 1]],
+                },
+            });
+        });
 
         it('does not parse the <M117 legacy format without timestamps', () => {
             const input = {

--- a/packages/rtcstats-shared/timeseries.js
+++ b/packages/rtcstats-shared/timeseries.js
@@ -33,8 +33,15 @@ export function createInternalsTimeSeries(connection) {
             return;
         }
         const timestamps = JSON.parse(connection.stats[statsId + '-timestamp'].values);
-        series[statsId][statsProperty] = JSON.parse(stats.values).map((currentValue, index) => {
-            return [timestamps[index], currentValue];
+        // Note: this does not work if a property only shows up on a stat "late".
+        // Observed e.g. with targetBitrate when the encoding is initially disabled.
+        // Then stats exist (and create a timestamp) but targetBitrate does not.
+        // Taking this from the end does not always work either, e.g. for remote rtcp-based
+        // reports.
+        const values = JSON.parse(stats.values);
+        const offset = timestamps.length - values.length;
+        series[statsId][statsProperty] = values.map((currentValue, index) => {
+            return [timestamps[index + offset], currentValue];
         });
     }
     return series;


### PR DESCRIPTION
The webrtc-internals format stores the timestamps separately from the actual values. This creates a problem if e.g. the property does initially not exist such as frameWidth or targetbitrate if the encoding is initially disabled.

While the stats have a starttime and endtime it is a human-readable time, not a timestamp so is missing the precision.

As a workaround, use an offset for mapping. This is not perfect but fixes the obvious issue at least.