### PR TITLE
js: trace `create` as first message on every connect

### DIFF
--- a/packages/rtcstats-js/test/e2e/trace-websocket.js
+++ b/packages/rtcstats-js/test/e2e/trace-websocket.js
@@ -61,6 +61,22 @@ describe('WebSocketTrace', () => {
         expect(JSON.parse(wsInstance.send.getCall(0).args)[2]).to.be.an('object');
     });
 
+    it('sends metadata and ws connection time on reconnect', async () => {
+        const trace = new WebSocketTrace();
+        trace.connect(TEST_WSURL);
+        await wsInstance.mockOpen();
+        expect(wsInstance.send.callCount).to.be.at.least(2);
+        expect(JSON.parse(wsInstance.send.getCall(0).args)[1]).to.equal(null);
+        expect(JSON.parse(wsInstance.send.getCall(0).args)[2]).to.be.an('object');
+
+        // Now reconnect.
+        trace.connect(TEST_WSURL);
+        await wsInstance.mockOpen();
+        expect(wsInstance.send.callCount).to.be.at.least(4);
+        expect(JSON.parse(wsInstance.send.getCall(0).args)).to.deep.equal(
+            JSON.parse(wsInstance.send.getCall(2).args));
+    });
+
     it('adds the timestamp at which the event was traced', async () => {
         const trace = new WebSocketTrace();
         const before = Date.now();

--- a/packages/rtcstats-js/trace-websocket.js
+++ b/packages/rtcstats-js/trace-websocket.js
@@ -8,6 +8,7 @@ export function WebSocketTrace(config = {}) {
     let connection;
     let lastTime = 0;
     let connectionStartTime = 0;
+    const createTime = Date.now();
 
     // This counts the number of times the trace itself has been initialized.
     // Typically this is done once per session and counting (re)loads based
@@ -47,21 +48,6 @@ export function WebSocketTrace(config = {}) {
             buffer.push(args);
         }
     };
-    trace('create', null, {
-        hardwareConcurrency: navigator.hardwareConcurrency,
-        userAgentData: navigator.userAgentData,
-        deviceMemory: navigator.deviceMemory,
-        screen: {
-            width: window.screen.availWidth,
-            height: window.screen.availHeight,
-            devicePixelRatio: window.devicePixelRatio,
-        },
-        window: {
-            width: window.innerWidth,
-            height: window.innerHeight,
-        },
-        reloadCount,
-    });
 
     trace.close = () => {
         if (window.sessionStorage && config.countReloads) {
@@ -94,6 +80,23 @@ export function WebSocketTrace(config = {}) {
             // Note: open is called while the socket is still authenticating.
             // This can lead to messages being send and dropped when the token
             // is not valid.
+
+            // Note: this does not use trace so avoids the buffer.
+            connection.send(JSON.stringify(['create', null, {
+                hardwareConcurrency: navigator.hardwareConcurrency,
+                userAgentData: navigator.userAgentData,
+                deviceMemory: navigator.deviceMemory,
+                screen: {
+                    width: window.screen.availWidth,
+                    height: window.screen.availHeight,
+                    devicePixelRatio: window.devicePixelRatio,
+                },
+                window: {
+                    width: window.innerWidth,
+                    height: window.innerHeight,
+                },
+                reloadCount,
+            }, createTime]));
             const connectionTime = Date.now() - connectionStartTime;
             setTimeout(function flush() {
                 if (!buffer.length) {


### PR DESCRIPTION
instead of just the first connection that is established.
This is particularly important since the server considers the
timestamp to be relative to the first timestamp received.
