### PR TITLE
js: fix timestamp on reconnect

### DIFF
--- a/packages/rtcstats-js/test/e2e/trace-websocket.js
+++ b/packages/rtcstats-js/test/e2e/trace-websocket.js
@@ -2,6 +2,7 @@ import {expect} from '@esm-bundle/chai';
 import sinon from 'sinon';
 
 import {WebSocketTrace} from '../../trace-websocket.js';
+import {compressMethod} from '@rtcstats/rtcstats-shared';
 
 class MockWebSocket extends EventTarget{
     constructor(...args) {
@@ -38,8 +39,8 @@ describe('WebSocketTrace', () => {
         trace.connect(TEST_WSURL);
         await wsInstance.mockOpen();
         expect(wsInstance.send.callCount).to.at.least(2);
-        expect(JSON.parse(wsInstance.send.getCall(1).args)[0]).to.equal('something');
-        expect(JSON.parse(wsInstance.send.getCall(1).args)[1]).to.equal(null);
+        expect(JSON.parse(wsInstance.send.getCall(0).args)[0]).to.equal('something');
+        expect(JSON.parse(wsInstance.send.getCall(0).args)[1]).to.equal(null);
     });
 
     it('buffers while connecting', async () => {
@@ -66,6 +67,7 @@ describe('WebSocketTrace', () => {
         trace.connect(TEST_WSURL);
         await wsInstance.mockOpen();
         expect(wsInstance.send.callCount).to.be.at.least(2);
+        expect(JSON.parse(wsInstance.send.getCall(0).args)[0]).to.equal(compressMethod('create'));
         expect(JSON.parse(wsInstance.send.getCall(0).args)[1]).to.equal(null);
         expect(JSON.parse(wsInstance.send.getCall(0).args)[2]).to.be.an('object');
 
@@ -73,8 +75,9 @@ describe('WebSocketTrace', () => {
         trace.connect(TEST_WSURL);
         await wsInstance.mockOpen();
         expect(wsInstance.send.callCount).to.be.at.least(4);
-        expect(JSON.parse(wsInstance.send.getCall(0).args)).to.deep.equal(
-            JSON.parse(wsInstance.send.getCall(2).args));
+        expect(JSON.parse(wsInstance.send.getCall(2).args)[0]).to.equal(compressMethod('create'));
+        expect(JSON.parse(wsInstance.send.getCall(2).args)[1]).to.equal(null);
+        expect(JSON.parse(wsInstance.send.getCall(2).args)[2]).to.be.an('object');
     });
 
     it('adds the timestamp at which the event was traced', async () => {

--- a/packages/rtcstats-js/trace-websocket.js
+++ b/packages/rtcstats-js/trace-websocket.js
@@ -6,9 +6,8 @@ const RELOAD_COUNT_KEY = 'rtcstatsReloadCount';
 export function WebSocketTrace(config = {}) {
     let buffer = [];
     let connection;
-    let lastTime = Date.now();
+    let lastTime = 0;
     let connectionStartTime = 0;
-    const createTime = Date.now();
 
     // This counts the number of times the trace itself has been initialized.
     // Typically this is done once per session and counting (re)loads based
@@ -56,12 +55,31 @@ export function WebSocketTrace(config = {}) {
         }
         if (connection) {
             connection.close();
+            connection = null;
         }
+        // New traces need to get an absolute timestamp.
+        lastTime = 0;
     };
     trace.connect = (wsURL) => {
         if (connection) {
             connection.close();
+            lastTime = 0;
         }
+        trace('create', null, {
+            hardwareConcurrency: navigator.hardwareConcurrency,
+            userAgentData: navigator.userAgentData,
+            deviceMemory: navigator.deviceMemory,
+            screen: {
+                width: window.screen.availWidth,
+                height: window.screen.availHeight,
+                devicePixelRatio: window.devicePixelRatio,
+            },
+            window: {
+                width: window.innerWidth,
+                height: window.innerHeight,
+            },
+            reloadCount,
+        });
         connectionStartTime = Date.now();
         connection = new WebSocket(wsURL, 'rtcstats#' + PROTOCOL_VERSION);
         connection.addEventListener('error', (e) => {
@@ -80,23 +98,6 @@ export function WebSocketTrace(config = {}) {
             // Note: open is called while the socket is still authenticating.
             // This can lead to messages being send and dropped when the token
             // is not valid.
-
-            // Note: this does not use trace so avoids the buffer.
-            connection.send(JSON.stringify([compressMethod('create'), null, {
-                hardwareConcurrency: navigator.hardwareConcurrency,
-                userAgentData: navigator.userAgentData,
-                deviceMemory: navigator.deviceMemory,
-                screen: {
-                    width: window.screen.availWidth,
-                    height: window.screen.availHeight,
-                    devicePixelRatio: window.devicePixelRatio,
-                },
-                window: {
-                    width: window.innerWidth,
-                    height: window.innerHeight,
-                },
-                reloadCount,
-            }, createTime]));
             const connectionTime = Date.now() - connectionStartTime;
             setTimeout(function flush() {
                 if (!buffer.length) {


### PR DESCRIPTION
which was relative to the last event sent, not to the trace

Fixes #214 and #216