### PR TITLE
js: bump version to 2.2.2

### DIFF
--- a/packages/rtcstats-js/package.json
+++ b/packages/rtcstats-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rtcstats/rtcstats-js",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "gather WebRTC API traces and statistics",
   "main": "rtcstats.js",
   "type": "module",


### PR DESCRIPTION
picking up #219. This should deprecate 2.2.0 and 2.2.1