### PR TITLE
js: simplify generateCertificate, only use computePressure if getStat…

### DIFF
--- a/packages/rtcstats-js/peerconnection.js
+++ b/packages/rtcstats-js/peerconnection.js
@@ -90,7 +90,7 @@ export function wrapRTCPeerConnection(trace, window, {getStatsInterval}) {
         return;
     }
     let lastComputePressureRecord;
-    if (window.PressureObserver) {
+    if (window.PressureObserver && getStatsInterval) {
         const observer = new PressureObserver((records) => {
             const lastRecord = records[records.length - 1]; // Usually only one record.
             lastComputePressureRecord = [Date.now(), lastRecord];
@@ -416,13 +416,7 @@ export function wrapRTCPeerConnection(trace, window, {getStatsInterval}) {
 
     // wrap static methods. Currently just generateCertificate.
     if (OrigPeerConnection.generateCertificate) {
-        Object.defineProperty(RTCStatsPeerConnection, 'generateCertificate', {
-            get(...args) {
-                return args.length ?
-                    OrigPeerConnection.generateCertificate.apply(null, args)
-                    : OrigPeerConnection.generateCertificate;
-            },
-        });
+        RTCStatsPeerConnection.generateCertificate = OrigPeerConnection.generateCertificate;
     }
     window.RTCPeerConnection = RTCStatsPeerConnection;
     window.RTCPeerConnection.prototype = OrigPeerConnection.prototype;

--- a/packages/rtcstats-js/trace-websocket.js
+++ b/packages/rtcstats-js/trace-websocket.js
@@ -14,11 +14,8 @@ export function WebSocketTrace(config = {}) {
     // on that does not require listening for onload etc.
     let reloadCount = undefined;
     if (window.sessionStorage && config.countReloads) {
-        reloadCount =  window.sessionStorage.getItem(RELOAD_COUNT_KEY);
-        if (reloadCount === null || isNaN(reloadCount)) {
-            reloadCount = -1;
-        }
-        reloadCount = parseInt(reloadCount, 10) + 1;
+        const stored = parseInt(window.sessionStorage.getItem(RELOAD_COUNT_KEY), 10);
+        reloadCount = Number.isNaN(stored) ? 0 : stored + 1;
         window.sessionStorage.setItem(RELOAD_COUNT_KEY, reloadCount);
     }
     const trace = function(...args) {


### PR DESCRIPTION
…sInternal is set and avoid reloadcount woes