### PR TITLE
bump rtcstats-shared to 2.3.0

### DIFF
--- a/packages/rtcstats-shared/package.json
+++ b/packages/rtcstats-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rtcstats/rtcstats-shared",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "main": "index.js",
   "description": "gather WebRTC API traces and statistics",
   "type": "module",


### PR DESCRIPTION
adding a missing LICENSE.md and containing #242, #212, #189 and #185