### PR TITLE
js: do not reset the trace timestamp baseline when close() has no connection

### DIFF
--- a/packages/rtcstats-js/test/e2e/trace-websocket.js
+++ b/packages/rtcstats-js/test/e2e/trace-websocket.js
@@ -123,6 +123,26 @@ describe('WebSocketTrace', () => {
         expect(wsInstance.close.callCount).to.equal(1);
     });
 
+    it('close() does not reset the timestamp baseline when there is no connection', async () => {
+        const trace = new WebSocketTrace();
+        const before = Date.now();
+        trace('something', null);
+        trace.close();
+        trace.connect(TEST_WSURL);
+        await wsInstance.mockOpen();
+        const after = Date.now();
+
+        expect(wsInstance.send.callCount).to.be.at.least(2);
+        const firstArgs = JSON.parse(wsInstance.send.getCall(0).args);
+        const secondArgs = JSON.parse(wsInstance.send.getCall(1).args);
+        expect(firstArgs[0]).to.equal(compressMethod('something'));
+        expect(secondArgs[0]).to.equal(compressMethod('create'));
+
+        const delta = after - before;
+        expect(firstArgs[firstArgs.length - 1]).to.be.within(before, after);
+        expect(secondArgs[secondArgs.length - 1]).to.be.at.most(delta);
+    });
+
     it('logs authorization errors if configured', async () => {
         const logStub = sinon.stub();
         const trace = new WebSocketTrace({log: logStub});

--- a/packages/rtcstats-js/trace-websocket.js
+++ b/packages/rtcstats-js/trace-websocket.js
@@ -53,9 +53,9 @@ export function WebSocketTrace(config = {}) {
         if (connection) {
             connection.close();
             connection = null;
+            // New traces need to get an absolute timestamp.
+            lastTime = 0;
         }
-        // New traces need to get an absolute timestamp.
-        lastTime = 0;
     };
     trace.connect = (wsURL) => {
         if (connection) {


### PR DESCRIPTION
When `trace.close()` was called before any `trace.connect()` (or after a previous close had already nulled out the connection), it still reset lastTime to 0.

The subsequent `connect()`'s implicit 'create' trace then landed with an absolute timestamp instead of a small delta, producing a second absolute timestamp in the buffer that was sent to the server.

Gate the lastTime reset on the same `if (connection)` branch that performs the actual teardown.