### PR TITLE
js: bump version 2.2.3

### DIFF
--- a/packages/rtcstats-js/package.json
+++ b/packages/rtcstats-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rtcstats/rtcstats-js",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "gather WebRTC API traces and statistics",
   "main": "rtcstats.js",
   "type": "module",


### PR DESCRIPTION
mainly for #252 but also logs WebSocket errors if configured