### PR TITLE
server: add host identifier command line argument

### DIFF
--- a/packages/rtcstats-server/app.js
+++ b/packages/rtcstats-server/app.js
@@ -1,11 +1,24 @@
 import cluster from 'node:cluster';
 import os from 'node:os';
 import process from 'node:process';
+import {parseArgs} from 'node:util';
 
 import config from 'config';
 
 import {RTCStatsServer} from './rtcstats-server.js';
 import {setupDirectory} from './utils.js';
+
+// Command-line parameters.
+//   --host-identifier <string>  Identifier for this server, stored with every
+//                               dump to attribute it to the server that
+//                               received it. Undefined when not provided.
+const {values: args} = parseArgs({
+    strict: false,
+    options: {
+        'host-identifier': {type: 'string'},
+    },
+});
+const hostIdentifier = args['host-identifier'];
 
 // Setup work and upload directories.
 setupDirectory(config, config.server.workDirectory);
@@ -30,6 +43,6 @@ if (cluster.isPrimary) {
         cluster.fork();
     }
 } else {
-    const server = new RTCStatsServer(config);
+    const server = new RTCStatsServer({...config, hostIdentifier});
     server.listen();
 }

--- a/packages/rtcstats-server/database/no-database.js
+++ b/packages/rtcstats-server/database/no-database.js
@@ -1,8 +1,8 @@
 export function createNoDatabase() {
     console.log('postgres not configured, skipping');
     return {
-        insert: (startTime, authData) => {
-            console.log('Not inserting into database', startTime, authData);
+        insert: (startTime, authData, hostIdentifier) => {
+            console.log('Not inserting into database', startTime, authData, hostIdentifier);
             return 'no-id';
         },
         update: (id, stopTime, blobUrl) => {

--- a/packages/rtcstats-server/database/postgres.js
+++ b/packages/rtcstats-server/database/postgres.js
@@ -17,7 +17,7 @@ export function createPostgres(config) {
     });
     return {
         sql, // raw SQL access.
-        insert: async (startTime, authData) => {
+        insert: async (startTime, authData, hostIdentifier) => {
             const startDate = new Date(startTime);
 
             // Extract authentication data.
@@ -31,10 +31,12 @@ export function createPostgres(config) {
             }
             const result = await sql`insert into ${sql(config.tableName)}
                     (session_start,
-                     rtcstats_user, rtcstats_conference, rtcstats_session)
+                     rtcstats_user, rtcstats_conference, rtcstats_session,
+                     host_identifier)
                     values
                     (${startDate.toISOString()},
-                     ${userId || null}, ${conferenceId || null}, ${sessionId || null}
+                     ${userId || null}, ${conferenceId || null}, ${sessionId || null},
+                     ${hostIdentifier || null}
                     )
                     returning id`;
             return result[0].id;

--- a/packages/rtcstats-server/rtcstats-server.js
+++ b/packages/rtcstats-server/rtcstats-server.js
@@ -82,7 +82,7 @@ export class RTCStatsServer {
                 const {metadata} = result;
                 const endTime = Date.now();
                 const startTime = metadata.startTime || Date.now();
-                const dbId = await this.database.insert(startTime, authData);
+                const dbId = await this.database.insert(startTime, authData, this.config.hostIdentifier);
                 process.nextTick(async() => {
                     console.log('Connection with uuid', clientId, 'uploaded via HTTP, starting to process data');
                     this.process(clientId, startTime, endTime, dbId);
@@ -139,7 +139,7 @@ export class RTCStatsServer {
             obfuscateIpAddresses: this.config.server.obfuscateIpAddresses,
         });
         metadata.fileFormat = this.config.rtcStats.fileFormat;
-        const dbId = await this.database.insert(startTime, authData);
+        const dbId = await this.database.insert(startTime, authData, this.config.hostIdentifier);
 
         const workPath = path.join(this.config.server.workDirectory, clientId);
         const writeStream = fs.createWriteStream(workPath);

--- a/supabase/migrations/20260601100000_add_host_identifier_to_rtcstats_server.sql
+++ b/supabase/migrations/20260601100000_add_host_identifier_to_rtcstats_server.sql
@@ -1,0 +1,1 @@
+alter table "public"."rtcstats-server" add column "host_identifier" text;


### PR DESCRIPTION
which gets written into the database. This allows grouping dumps by server. Up to the deployment script to fill the value