### PR TITLE
features: add (audio) jitterBufferFlushes and detect periodic ones

### DIFF
--- a/packages/rtcstats-features/features.md
+++ b/packages/rtcstats-features/features.md
@@ -363,6 +363,8 @@ All fields below are read from the last `getStats` report containing the track's
 | `jitterBufferMinimumDelay` | number | last getStats | Cumulative jitter buffer minimum target delay. |
 | `jitterBufferTargetDelay` | number | last getStats | Cumulative jitter buffer target delay. |
 | `jitterBufferEmittedCount` | number | last getStats | Cumulative frames/samples emitted by the jitter buffer. |
+| `jitterBufferFlushes` | number | last getStats | Cumulative number of times the [jitter buffer was flushed](https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-jitterbufferflushes). |
+| `hasPeriodicJitterBufferFlushes` | boolean | aggregated getStats | Whether `jitterBufferFlushes` increments at a regular roughly-four-second cadence (a known NetEq pathology), detected from at least three increments (audio only). |
 | `totalProcessingDelay` | number | last getStats | Cumulative processing delay. |
 | `framesAssembledFromMultiplePackets` | number | last getStats | Cumulative frames that required multiple packets to assemble. |
 | `totalAssemblyTime` | number | last getStats | Cumulative time spent assembling frames from packets. |

--- a/packages/rtcstats-features/features/track.js
+++ b/packages/rtcstats-features/features/track.js
@@ -84,6 +84,41 @@ function resolutionFeatures(/* clientTrace*/_, peerConnectionTrace, trackInforma
     };
 }
 
+function audioJitterBufferFeatures(/* clientTrace*/_, peerConnectionTrace, trackInformation) {
+    // NetEq flushes the jitter buffer when it falls too far behind.
+    // If this happens periodically every four seconds something is very wrong.
+    if (trackInformation.direction !== 'inbound' || trackInformation.kind !== 'audio') {
+        return {};
+    }
+    const flushTimestamps = [];
+    let seen = false;
+    let lastFlushes;
+    for (const traceEvent of peerConnectionTrace) {
+        if (traceEvent.type !== 'getStats' || !traceEvent.value) continue;
+        const stats = traceEvent.value[trackInformation.statsId];
+        if (!stats || !stats.hasOwnProperty('jitterBufferFlushes')) continue;
+        seen = true;
+        const flushes = stats.jitterBufferFlushes;
+        if (lastFlushes !== undefined && flushes > lastFlushes) {
+            flushTimestamps.push(traceEvent.timestamp);
+        }
+        lastFlushes = flushes;
+    }
+    if (!seen || flushTimestamps.length < 3) {
+        return {};
+    }
+    // getStats polls roughly every second, so a periodic four-second cadence is observed somewhere in [3000, 5000].
+    let hasPeriodicJitterBufferFlushes = true;
+    for (let i = 1; i < flushTimestamps.length; i++) {
+        const interval = flushTimestamps[i] - flushTimestamps[i - 1];
+        if (interval < 3000 || interval > 5000) {
+            hasPeriodicJitterBufferFlushes = false;
+            break;
+        }
+    }
+    return {hasPeriodicJitterBufferFlushes};
+}
+
 function lastStatsFeatures(/* clientTrace*/_, peerConnectionTrace, trackInformation) {
     const features = {
         duration: 0,
@@ -158,6 +193,7 @@ function lastStatsFeatures(/* clientTrace*/_, peerConnectionTrace, trackInformat
         features['jitterBufferMinimumDelay'] = pluckStat(lastTrackStats, ['jitterBufferMinimumDelay']);
         features['jitterBufferTargetDelay'] = pluckStat(lastTrackStats, ['jitterBufferTargetDelay']);
         features['jitterBufferEmittedCount'] = pluckStat(lastTrackStats, ['jitterBufferEmittedCount']);
+        features['jitterBufferFlushes'] = pluckStat(lastTrackStats, ['jitterBufferFlushes']);
         features['totalProcessingDelay'] = pluckStat(lastTrackStats, ['totalProcessingDelay']);
 
         features['framesAssembledFromMultiplePackets'] = pluckStat(lastTrackStats, ['framesAssembledFromMultiplePackets']);
@@ -193,6 +229,7 @@ export function extractTrackFeatures(/* clientTrace*/_, peerConnectionTrace, tra
         ...codecFeatures(undefined, peerConnectionTrace, trackInformation),
         ...features,
         ...resolutionFeatures(undefined, peerConnectionTrace, trackInformation),
+        ...audioJitterBufferFeatures(undefined, peerConnectionTrace, trackInformation),
         ...lastStatsFeatures(undefined, peerConnectionTrace, trackInformation),
     };
 }

--- a/packages/rtcstats-features/test/track.js
+++ b/packages/rtcstats-features/test/track.js
@@ -146,6 +146,7 @@ describe('extractTrackFeatures', () => {
                 jitterBufferMinimumDelay: 1,
                 jitterBufferTargetDelay: 2,
                 jitterBufferEmittedCount: 100,
+                jitterBufferFlushes: 3,
                 totalProcessingDelay: 5,
                 framesAssembledFromMultiplePackets: 50,
                 totalAssemblyTime: 2.5,
@@ -179,6 +180,7 @@ describe('extractTrackFeatures', () => {
             expect(features.jitterBufferMinimumDelay).to.equal(1);
             expect(features.jitterBufferTargetDelay).to.equal(2);
             expect(features.jitterBufferEmittedCount).to.equal(100);
+            expect(features.jitterBufferFlushes).to.equal(3);
             expect(features.totalProcessingDelay).to.equal(5);
             expect(features.averageJitterBufferDelay).to.equal(0.1);
             expect(features.averageProcessingDelay).to.equal(0.05);
@@ -406,6 +408,38 @@ describe('extractTrackFeatures', () => {
             expect(features.concealedSamples).to.be.undefined;
             expect(features.totalSamplesReceived).to.be.undefined;
             expect(features.concealmentPercentage).to.be.undefined;
+        });
+    });
+
+    describe('audio jitter buffer flush features', () => {
+        const trackInfo = {
+            direction: 'inbound',
+            id: 'track1',
+            kind: 'audio',
+            startTime: 1000,
+            statsId: 'track1_stats',
+        };
+        // getStats is polled once a second; jitterBufferFlushes steps up every flushIntervalMs.
+        const traceFromFlushes = (flushes, flushIntervalMs = 4000) => {
+            const trace = [];
+            for (let t = 0; t <= flushes * flushIntervalMs; t += 1000) {
+                trace.push({
+                    timestamp: 1000 + t,
+                    type: 'getStats',
+                    value: {'track1_stats': {jitterBufferFlushes: Math.floor(t / flushIntervalMs), type: 'inbound-rtp'}},
+                });
+            }
+            return trace;
+        };
+
+        it('detects a roughly four-second flush cadence', () => {
+            const features = extractTrackFeatures([], traceFromFlushes(5), trackInfo);
+            expect(features.hasPeriodicJitterBufferFlushes).to.equal(true);
+        });
+
+        it('does not flag flushes that are too far apart', () => {
+            const features = extractTrackFeatures([], traceFromFlushes(4, 8000), trackInfo);
+            expect(features.hasPeriodicJitterBufferFlushes).to.equal(false);
         });
     });
 });

--- a/supabase/migrations/20260625100000_add_jitter_buffer_flush_features_to_features_track.sql
+++ b/supabase/migrations/20260625100000_add_jitter_buffer_flush_features_to_features_track.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."features_track" ADD COLUMN jitter_buffer_flushes INTEGER;
+ALTER TABLE "public"."features_track" ADD COLUMN has_periodic_jitter_buffer_flushes BOOLEAN;


### PR DESCRIPTION
which should help detecting issues like
  https://issues.webrtc.org/issues/525729347
where NetEq receives packets but those are never polled from the buffer, leading to flushes.