### PR TITLE
js: stop polling getStats for react-native-webrtc too

### DIFF
--- a/packages/rtcstats-js/peerconnection.js
+++ b/packages/rtcstats-js/peerconnection.js
@@ -188,7 +188,7 @@ export function wrapRTCPeerConnection(trace, window, {getStatsInterval}) {
         let statsInterval;
         const statsIdMap = {};
         const getStats = async (reason) => {
-            if (pc.signalingState === 'closed') {
+            if (pc.signalingState === 'closed' || pc.connectionState === 'closed') {
                 if (statsInterval) {
                     window.clearInterval(statsInterval);
                 }


### PR DESCRIPTION
which due to a bug in the event order does not set signalingState to `closed`.

Upstream fix in
  https://github.com/react-native-webrtc/react-native-webrtc/pull/1821