### PR TITLE
js: don't rely on window.screen being set

### DIFF
--- a/packages/rtcstats-js/trace-websocket.js
+++ b/packages/rtcstats-js/trace-websocket.js
@@ -68,8 +68,8 @@ export function WebSocketTrace(config = {}) {
             userAgentData: navigator.userAgentData,
             deviceMemory: navigator.deviceMemory,
             screen: {
-                width: window.screen.availWidth,
-                height: window.screen.availHeight,
+                width: window.screen?.availWidth,
+                height: window.screen?.availHeight,
                 devicePixelRatio: window.devicePixelRatio,
             },
             window: {


### PR DESCRIPTION
which it isn't in react-native(-webrtc)