### PR TITLE
features: guard divideStat against divide-by-zero, dedupe into statUtils

### DIFF
--- a/packages/rtcstats-features/features/connection.js
+++ b/packages/rtcstats-features/features/connection.js
@@ -1,14 +1,7 @@
 /* eslint sort-keys: "error" */
 import SDPUtils from 'sdp';
 
-function pluckStat(statsObject, properties) {
-    if (!statsObject) return;
-    for (const property of properties) {
-        if (statsObject.hasOwnProperty(property)) {
-            return statsObject[property];
-        }
-    }
-}
+import {divideStat, pluckStat} from '../statUtils.js';
 
 function getSelectedCandidatePairStats(report) {
     const transportId = Object.keys(report).find(id => {
@@ -392,7 +385,7 @@ function lastStatsFeatures(/* clientTrace*/_, peerConnectionTrace) {
     if (!(lastStatsEvent && lastCandidatePairStats)) {
         return features;
     }
-    features['averageStunRoundTripTime'] = pluckStat(lastCandidatePairStats, ['totalRoundTripTime']) / pluckStat(lastCandidatePairStats, ['responsesReceived']);
+    features['averageStunRoundTripTime'] = divideStat(lastCandidatePairStats, 'totalRoundTripTime', 'responsesReceived');
     if (firstStatsEvent && firstStatsEvent.timestamp < lastStatsEvent.timestamp) {
         const deltaSeconds = (lastStatsEvent.timestamp - firstStatsEvent.timestamp) / 1000;
         features['averageOutboundBitrate'] = ((pluckStat(lastCandidatePairStats, ['bytesSent']) - pluckStat(firstCandidatePairStats, ['bytesSent'])) * 8) / deltaSeconds;

--- a/packages/rtcstats-features/features/track.js
+++ b/packages/rtcstats-features/features/track.js
@@ -3,22 +3,7 @@ import SDPUtils from 'sdp';
 
 import {parseTrackWithStreams} from '@rtcstats/rtcstats-shared';
 
-function pluckStat(statsObject, properties) {
-    if (!statsObject) return;
-    for (const property of properties) {
-        if (statsObject.hasOwnProperty(property)) {
-            return statsObject[property];
-        }
-    }
-}
-
-function divideStat(statsObject, nominator, denominator) {
-    if (!statsObject) return;
-    if (!(statsObject.hasOwnProperty(nominator) && statsObject.hasOwnProperty(denominator))) {
-        return undefined;
-    }
-    return statsObject[nominator] / statsObject[denominator];
-}
+import {divideStat, pluckStat} from '../statUtils.js';
 
 function codecFeatures(/* clientTrace*/_, peerConnectionTrace, trackInformation) {
     for (const traceEvent of peerConnectionTrace) {

--- a/packages/rtcstats-features/statUtils.js
+++ b/packages/rtcstats-features/statUtils.js
@@ -1,0 +1,21 @@
+/* eslint sort-keys: "error" */
+
+export function pluckStat(statsObject, properties) {
+    if (!statsObject) return;
+    for (const property of properties) {
+        if (statsObject.hasOwnProperty(property)) {
+            return statsObject[property];
+        }
+    }
+}
+
+export function divideStat(statsObject, nominator, denominator) {
+    if (!statsObject) return;
+    if (!(statsObject.hasOwnProperty(nominator) && statsObject.hasOwnProperty(denominator))) {
+        return undefined;
+    }
+    if (statsObject[denominator] === 0) {
+        return undefined;
+    }
+    return statsObject[nominator] / statsObject[denominator];
+}

--- a/packages/rtcstats-features/test/connection.js
+++ b/packages/rtcstats-features/test/connection.js
@@ -552,6 +552,21 @@ describe('extractConnectionFeatures', () => {
         expect(features.averageOutboundBitrate).to.be.undefined;
     });
 
+    it('should not divide by zero when no STUN responses were received', () => {
+        const pcTrace = [
+            {
+                type: 'getStats',
+                value: {
+                    1: { type: 'transport', selectedCandidatePairId: '2' },
+                    2: { type: 'candidate-pair', totalRoundTripTime: 0, responsesReceived: 0 },
+                },
+                timestamp: 1001,
+            },
+        ];
+        const features = extractConnectionFeatures([], pcTrace);
+        expect(features.averageStunRoundTripTime).to.be.undefined;
+    });
+
     it('should extract average inbound and outbound bitrate', () => {
         const pcTrace = [
             {


### PR DESCRIPTION
divideStat now returns undefined when the denominator is 0, so no NaN/Infinity ratios reach the DB. averageStunRoundTripTime moves from a manual pluckStat division to divideStat, yielding undefined when a candidate pair received no STUN responses. pluckStat/divideStat are deduped from connection.js and track.js into a shared statUtils.js.