### PR TITLE
server: stream dump to rtcstats.com instead of buffering it in memory

### DIFF
--- a/packages/rtcstats-server/rtcstats-server.js
+++ b/packages/rtcstats-server/rtcstats-server.js
@@ -215,16 +215,16 @@ export class RTCStatsServer {
         const blobLocation = await this.storage.put(clientId, destPath);
 
         if (this.rtcstatsUploader) {
-            // Read data and upload to rtcstats.com if configured.
-            const data = await fsPromises.readFile(destPath);
-            data.name = clientId;
-            data.size = data.length;
+            // Upload to rtcstats.com if configured.
             let response;
+            const fileHandle = await fsPromises.open(destPath);
             try {
-                response = await this.rtcstatsUploader(data);
+                response = await this.rtcstatsUploader(fileHandle, clientId);
             } catch (e) {
                 // Should an error prevent deletion?
                 console.error('Uploading to rtcstats.com failed', e);
+            } finally {
+                await fileHandle.close();
             }
             if (response && response.url) {
                 await this.database.setRtcStatsEmbedUrl(dbId, response.url);

--- a/packages/rtcstats-server/storage/rtcstats-com.js
+++ b/packages/rtcstats-server/storage/rtcstats-com.js
@@ -1,19 +1,21 @@
 const CHUNK_SIZE = 1024 * 1024; // 1MB
 
-export async function uploadToRtcStatsCom(file, endpoint, token, fetchFunction) {
+export async function uploadToRtcStatsCom(fileHandle, name, endpoint, token, fetchFunction) {
+    const {size} = await fileHandle.stat();
     // Upload individual chunks.
-    const totalChunks = Math.ceil(file.size / CHUNK_SIZE);
-    const fileId = `${file.name}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const totalChunks = Math.ceil(size / CHUNK_SIZE);
+    const fileId = `${name}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     for (let i = 0; i < totalChunks; i++) {
         const start = i * CHUNK_SIZE;
-        const end = Math.min(file.size, start + CHUNK_SIZE);
-        const chunk = file.slice(start, end);
+        const end = Math.min(size, start + CHUNK_SIZE);
+        const buffer = Buffer.allocUnsafe(end - start);
+        const {bytesRead} = await fileHandle.read(buffer, 0, end - start, start);
         const formData = new FormData();
-        formData.append('chunk', new Blob([chunk]));
+        formData.append('chunk', new Blob([buffer.subarray(0, bytesRead)]));
         formData.append('fileId', fileId);
         formData.append('chunkIndex', i.toString());
         formData.append('totalChunks', totalChunks.toString());
-        formData.append('fileName', file.name);
+        formData.append('fileName', name);
         const response = await fetchFunction(endpoint, {
             method: 'POST',
             headers: {
@@ -29,7 +31,7 @@ export async function uploadToRtcStatsCom(file, endpoint, token, fetchFunction) 
     // Notify server to assemble.
     const assembleResponse = await fetchFunction(endpoint, {
         method: 'POST',
-        body: JSON.stringify({ fileId, assemble: true, fileName: file.name }),
+        body: JSON.stringify({ fileId, assemble: true, fileName: name }),
         headers: {
             'Content-Type': 'application/json',
             'Authorization': `Bearer ${token}`,
@@ -54,10 +56,10 @@ export function createRtcStatsUploader(config) {
     // Only for testing.
     const fetchFunction = config.fetch || fetch;
     const randomFunction = config.random || Math.random;
-    return (file) => {
+    return (fileHandle, name) => {
         if (randomFunction() >= randomPercentage) {
             return;
         }
-        return uploadToRtcStatsCom(file, config.endpoint, config.token, fetchFunction);
+        return uploadToRtcStatsCom(fileHandle, name, config.endpoint, config.token, fetchFunction);
     };
 }

--- a/packages/rtcstats-server/test/storage.js
+++ b/packages/rtcstats-server/test/storage.js
@@ -13,9 +13,19 @@ describe('Storage', () => {
                 json: () => {},
             };
         };
-        const testFile = Buffer.from('hello world', 'ascii');
-        testFile.size = testFile.length;
-        testFile.name = 'testname';
+        // Minimal fs.FileHandle stand-in backed by a Buffer.
+        const fileHandleFor = (contents) => ({
+            reads: [],
+            stat() {
+                return Promise.resolve({size: contents.length});
+            },
+            read(buffer, offset, length, position) {
+                this.reads.push([position, position + length]);
+                const bytesRead = contents.copy(buffer, offset, position, position + length);
+                return Promise.resolve({bytesRead});
+            },
+        });
+        const testFile = fileHandleFor(Buffer.from('hello world', 'ascii'));
 
         it('does not create an uploader if endpoint is undefined', () => {
             const uploader = createRtcStatsUploader({
@@ -45,7 +55,7 @@ describe('Storage', () => {
                 fetch: fetchMock,
                 randomPercentage: 0,
             });
-            await uploader(testFile);
+            await uploader(testFile, 'testname');
             expect(fetchArgs).to.have.length(0);
         });
         it('uploads when the random value is below the sampling percentage', async () => {
@@ -56,7 +66,7 @@ describe('Storage', () => {
                 random: () => 0.3,
                 randomPercentage: 0.5,
             });
-            await uploader(testFile);
+            await uploader(testFile, 'testname');
             expect(fetchArgs).to.have.length(2);
         });
         it('does not upload when the random value is above the sampling percentage', async () => {
@@ -67,7 +77,7 @@ describe('Storage', () => {
                 random: () => 0.7,
                 randomPercentage: 0.5,
             });
-            await uploader(testFile);
+            await uploader(testFile, 'testname');
             expect(fetchArgs).to.have.length(0);
         });
         it('splits the data for uploading', async () => {
@@ -76,8 +86,25 @@ describe('Storage', () => {
                 endpoint: 'http://example.com/',
                 fetch: fetchMock,
             });
-            await uploader(testFile);
+            await uploader(testFile, 'testname');
             expect(fetchArgs).to.have.length(2);
+        });
+        it('reads the file one chunk at a time instead of buffering it whole', async () => {
+            const chunkSize = 1024 * 1024;
+            const handle = fileHandleFor(Buffer.alloc(chunkSize * 2 + 10));
+            const uploader = createRtcStatsUploader({
+                token: 'abc',
+                endpoint: 'http://example.com/',
+                fetch: fetchMock,
+            });
+            await uploader(handle, 'testname');
+            // Three chunk uploads plus the assemble call.
+            expect(fetchArgs).to.have.length(4);
+            expect(handle.reads).to.deep.equal([
+                [0, chunkSize],
+                [chunkSize, chunkSize * 2],
+                [chunkSize * 2, chunkSize * 2 + 10],
+            ]);
         });
     });
 });


### PR DESCRIPTION
uploadDump opens the post-processed dump as an fs.FileHandle and passes it to the rtcstats.com uploader, which stats for the size and reads one CHUNK_SIZE chunk at a time via positional reads, rather than slurping the whole file with readFile. Peak memory per forward drops from the full uncompressed dump to ~1 chunk. The payload sent to rtcstats.com is unchanged (same FormData fields + assemble call).