### PR TITLE
shared: fix duplicate getUserMediaOnFailure key in method compression table

### DIFF
--- a/packages/rtcstats-shared/compression.js
+++ b/packages/rtcstats-shared/compression.js
@@ -371,12 +371,20 @@ const methodTable = {
     // getUserMedia and friends.
     'navigator.mediaDevices.getUserMedia': 60,
     'navigator.mediaDevices.getUserMediaOnSuccess': 61,
-    'navigator.mediaDevices.getUserMediaOnFailure': 62,
+    // 62 is not usable. It was originally assigned to
+    // getUserMediaOnFailure but a copy-paste bug duplicated the
+    // key onto 65, which was intended for getDisplayMediaOnFailure.
+    // The last duplicate key wins in an object literal, so released clients
+    // have always compressed getUserMediaOnFailure to 65.
+    'navigator.mediaDevices.getUserMediaOnFailure': 65,
     'navigator.mediaDevices.getDisplayMedia': 63,
     'navigator.mediaDevices.getDisplayMediaOnSuccess': 64,
-    'navigator.mediaDevices.getUserMediaOnFailure': 65,
     'navigator.mediaDevices.enumerateDevices': 66,
     'navigator.mediaDevices.ondevicechange': 67,
+    // Decompression-only until the next major version bump, see below.
+    // This method is therefore not compressed.
+    // 'navigator.mediaDevices.getDisplayMediaOnFailure': 68,
+    // Next free method id: 69.
     // MediaStreamTrack methods and events.
     'MediaStreamTrack.stop':  70,
     'MediaStreamTrack.applyConstraints':  71,
@@ -390,6 +398,7 @@ const methodTable = {
 // These should be moved to the compression table at major version bumps.
 const methodTableDecompression = {
     1: 'getStats',
+    68: 'navigator.mediaDevices.getDisplayMediaOnFailure',
 };
 const reverseMethodTable = Object.keys(methodTable).reduce((table, method) => {
     table[methodTable[method]] = method;

--- a/packages/rtcstats-shared/test/compression.js
+++ b/packages/rtcstats-shared/test/compression.js
@@ -336,6 +336,12 @@ describe('method compression', () => {
         expect(decompressMethod('g')).to.equal('getStats');
         expect(decompressMethod(1)).to.equal('getStats');
     });
+    it('only decompresses getDisplayMediaOnFailure but does not compress it (yet)', () => {
+        expect(compressMethod('navigator.mediaDevices.getDisplayMediaOnFailure'))
+            .to.equal('navigator.mediaDevices.getDisplayMediaOnFailure');
+        expect(decompressMethod(68))
+            .to.equal('navigator.mediaDevices.getDisplayMediaOnFailure');
+    });
 });
 
 describe('stats type compression', () => {


### PR DESCRIPTION
The method compression table listed navigator.mediaDevices.getUserMediaOnFailure twice, at 62 and again at 65 where getDisplayMediaOnFailure was clearly intended. Later duplicate keys win in object literals, so the table silently collapsed to a single entry with value 65. As a result:
- getUserMediaOnFailure has always compressed to 65 in released clients; 62 was never emitted nor decompressed by any version.
- getDisplayMediaOnFailure was never compressed and went over the wire as the full string.

Resolve this by accepting reality over the original intent:
- getUserMediaOnFailure keeps 65, so existing dumps and deployed clients remain correctly decoded forever.
- 62 is retired and MUST NOT be reused.
- getDisplayMediaOnFailure gets the next free slot, 68, staged decompression-first like the getStats 'g' to 1 migration: servers learn to decode 68 now, clients only start emitting it at the next major version bump once decoders have rolled out. Until then it continues to go over the wire as the full string, which is acceptable since getDisplayMedia rejections are rare events.