### PR TITLE
shared: do not modify the base stats during decompression

### DIFF
--- a/packages/rtcstats-shared/compression.js
+++ b/packages/rtcstats-shared/compression.js
@@ -180,18 +180,20 @@ export function statsDecompression(baseStatsInput, delta) {
         const hasOwnTimestamp = newStats[id] !== undefined &&
             newStats[id].timestamp !== undefined;
         if (!newStats[id]) {
-            newStats[id] = baseStats[id];
+            // Copy the report so the timestamp assignment below does not
+            // modify the base stats.
+            newStats[id] = Object.assign({}, baseStats[id]);
         } else {
             const report = baseStats[id];
             Object.keys(report).forEach(name => {
                 if (newStats[id][name] === undefined) {
                     newStats[id][name] = report[name];
-                } else if (typeof(report[name]) === 'object') {
-                    const newObject = newStats[id][name];
-                    newStats[id][name] = report[name];
-                    Object.keys(newObject).forEach(key => {
-                        newStats[id][name][key] = newObject[key];
-                    });
+                } else if (typeof(report[name]) === 'object' &&
+                        !Array.isArray(newStats[id][name])) {
+                    // Merge into a copy so the nested object of the
+                    // base stats is not modified. Arrays are serialized
+                    // wholesale on change and take the new value.
+                    newStats[id][name] = Object.assign({}, report[name], newStats[id][name]);
                 } // Else: take the new value.
             });
         }

--- a/packages/rtcstats-shared/dump.js
+++ b/packages/rtcstats-shared/dump.js
@@ -62,8 +62,9 @@ export async function readRTCStatsDump(blob) {
         const time = new Date(lastTime);
 
         if (method === 'getStats') { // delta-compressed stats
+            // statsDecompression does not modify its base stats argument.
             value = statsDecompression(baseStats[connection_id], value);
-            baseStats[connection_id] = JSON.parse(JSON.stringify(value));
+            baseStats[connection_id] = value;
         } else if (method === 'setLocalDescription' && value &&
             // Workaround for Chrome <145 bug: https://source.chromium.org/chromium/chromium/src/+/4a2a384e43ea163127219548087e949fb00fa562
             connection_id !== 'undefined-undefined') {


### PR DESCRIPTION
statsDecompression modified the base stats object it was given: reports absent from the delta were shared by reference and then had their timestamp assigned, and changed nested objects were merged into the base stats object. The dump reader defended against this with a full JSON deep copy of the decompressed result on every getStats frame.

Copy instead of modifying: unchanged reports and partially changed nested objects are shallow-copied, changed arrays are taken wholesale from the delta. This makes the API safe for consumers that keep a timeline of decompressed frames and lets the dump reader drop the per-frame deep copy.