### PR TITLE
shared: round floating point stats values to a per-property precision

### DIFF
--- a/packages/rtcstats-js/peerconnection.js
+++ b/packages/rtcstats-js/peerconnection.js
@@ -5,6 +5,7 @@ import {
     computePressureTable,
 } from '@rtcstats/rtcstats-shared';
 import {map2obj, dumpTrackWithStreams, copyAndSanitizeConfig} from '@rtcstats/rtcstats-shared';
+import {truncateStatsReport} from '@rtcstats/rtcstats-shared';
 
 /**
  * Wraps a RTCRtpTransceiver for RTCStats. Currently applied to these methods:
@@ -206,6 +207,16 @@ export function wrapRTCPeerConnection(trace, window, {getStatsInterval}) {
                     cpuState: computePressureTable[record.state] || record.state,
                 };
             }
+            // Round floating point values to a per-property precision before
+            // snapshotting and delta-compressing. This shortens serialized
+            // values and lets values that only jitter below the precision
+            // threshold drop out of the delta entirely. Applied before the
+            // base snapshot so prevStats and stats stay consistent.
+            Object.keys(stats).forEach((id) => {
+                if (stats[id] && typeof stats[id] === 'object') {
+                    truncateStatsReport(stats[id]);
+                }
+            });
             const baseStats = JSON.parse(JSON.stringify(stats)); // our new prevStats.
             const compressedStats = statsCompression(prevStats, stats, statsIdMap);
             if (reason) {

--- a/packages/rtcstats-shared/index.d.ts
+++ b/packages/rtcstats-shared/index.d.ts
@@ -17,6 +17,9 @@ export function decompressStatsType(typeKey: string | number): string;
 export function compressStatsProperty(property: string): string | number;
 export function decompressStatsProperty(property: string | number): string;
 
+export function truncateStatsValue(property: string, value: any): any;
+export function truncateStatsReport(rtcStats: object): object;
+
 export function createInternalsTimeSeries(connection: any): object;
 export function createRtcStatsTimeSeries(trace: any[]): object;
 export function insertNullForGapsIntoTimeSeries(timeSeries: any[], gapSizeMs?: number): any[];

--- a/packages/rtcstats-shared/index.js
+++ b/packages/rtcstats-shared/index.js
@@ -1,4 +1,5 @@
 export * from './compression.js';
+export * from './precision.js';
 export * from './dump.js';
 export * from './timeseries.js';
 export * from './utils.js';

--- a/packages/rtcstats-shared/precision.js
+++ b/packages/rtcstats-shared/precision.js
@@ -1,0 +1,86 @@
+// Per-property precision policy for getStats double values.
+//
+// getStats serializes doubles at full precision, so float noise like
+// `"totalSamplesDuration":1.0000000000000007` or
+// `"audioLevel":0.00003051850947599719` is paid on every tick. Rounding each
+// double to a per-property precision keeps the serialized values compact and,
+// as a second-order effect in delta compression, lets values that only jitter
+// below the precision threshold drop out of the delta entirely.
+//
+// This is lossy but not a wire-format change: only the producer rounds,
+// decompression is untouched, and old and new readers agree. A flat "3
+// decimals" rule does not work (audioLevel and totalAudioEnergy have near-zero
+// magnitudes that get wiped out), hence the small per-property override table.
+//
+// Kept as its own module so it can be shared by rtcstats-js and stay in sync
+// with the identical table shipped in Chromium's webrtc-internals frontend.
+
+// Class A: round to integer. Epoch-ms timestamps and bitrate estimates.
+const PRECISION_INTEGER = new Set([
+    'timestamp',
+    'lastPacketSentTimestamp',
+    'lastPacketReceivedTimestamp',
+    'estimatedPlayoutTimestamp',
+    'remoteTimestamp',
+    'targetBitrate',
+    'availableOutgoingBitrate',
+    'availableIncomingBitrate',
+]);
+
+// Class B: 5 significant digits. Magnitude spans decades (audioLevel is
+// quantized to multiples of 1/32768, totalAudioEnergy increments start around
+// 1e-9), so fixed decimals destroy them.
+const PRECISION_5SIGNIFICANT = new Set([
+    'audioLevel',
+    'totalAudioEnergy',
+]);
+
+// Class C: 6 decimals. jitter is multiples of 1/clockRate (~20 microseconds
+// at 48 kHz), so 1 ms resolution would quantize it away. Round trip times are
+// seconds-scale but 1 ms resolution is plenty for them, so they fall to the
+// Class D default rather than here.
+const PRECISION_6DECIMALS = new Set([
+    'jitter',
+]);
+
+/**
+ * Round a single stats value to the precision appropriate for `property`.
+ * Non-numbers, non-finite numbers (Infinity/NaN) and integers are returned
+ * unchanged. Class D (3 decimals) is the default for any other non-integer
+ * number.
+ * @param {string} property - stats property name.
+ * @param {*} value - stats value.
+ *
+ * @returns {*} value rounded to its per-property precision.
+ */
+export function truncateStatsValue(property, value) {
+    if (typeof value !== 'number' || !Number.isFinite(value) ||
+            Number.isInteger(value)) {
+        return value;
+    }
+    if (PRECISION_INTEGER.has(property)) {
+        return Math.round(value);
+    }
+    if (PRECISION_5SIGNIFICANT.has(property)) {
+        return Number(value.toPrecision(5));
+    }
+    if (PRECISION_6DECIMALS.has(property)) {
+        return Math.round(value * 1e6) / 1e6;
+    }
+    return Math.round(value * 1e3) / 1e3; // Class D default: 3 decimals.
+}
+
+/**
+ * Round every own numeric property of an RTCStats object in place.
+ * Nested objects (e.g. map-valued members like qualityLimitationDurations)
+ * are left untouched.
+ * @param {object} rtcStats - a single stats object.
+ *
+ * @returns {object} the same object, mutated in place.
+ */
+export function truncateStatsReport(rtcStats) {
+    for (const property of Object.keys(rtcStats)) {
+        rtcStats[property] = truncateStatsValue(property, rtcStats[property]);
+    }
+    return rtcStats;
+}

--- a/packages/rtcstats-shared/test/precision.js
+++ b/packages/rtcstats-shared/test/precision.js
@@ -1,0 +1,95 @@
+import {truncateStatsValue, truncateStatsReport} from '../precision.js';
+
+describe('precision', () => {
+    describe('truncateStatsValue', () => {
+        it('passes non-numbers through unchanged', () => {
+            expect(truncateStatsValue('mimeType', 'audio/opus')).to.equal('audio/opus');
+            expect(truncateStatsValue('active', true)).to.equal(true);
+            expect(truncateStatsValue('someObject', {a: 1})).to.deep.equal({a: 1});
+            expect(truncateStatsValue('missing', undefined)).to.equal(undefined);
+            expect(truncateStatsValue('missing', null)).to.equal(null);
+        });
+
+        it('passes integers through unchanged', () => {
+            expect(truncateStatsValue('bytesReceived', 123456)).to.equal(123456);
+            // Even for integer-class properties, integers are untouched.
+            expect(truncateStatsValue('timestamp', 1783323850971)).to.equal(1783323850971);
+        });
+
+        it('passes Infinity and NaN through unchanged', () => {
+            expect(truncateStatsValue('jitter', Infinity)).to.equal(Infinity);
+            expect(truncateStatsValue('jitter', -Infinity)).to.equal(-Infinity);
+            expect(Number.isNaN(truncateStatsValue('jitter', NaN))).to.equal(true);
+        });
+
+        it('rounds Class A properties to integer', () => {
+            expect(truncateStatsValue('timestamp', 1783323850971.656)).to.equal(1783323850972);
+            expect(truncateStatsValue('availableOutgoingBitrate', 1234567.89)).to.equal(1234568);
+            expect(truncateStatsValue('remoteTimestamp', 42.4)).to.equal(42);
+        });
+
+        it('rounds Class B properties to 5 significant digits', () => {
+            // audioLevel quantized to a multiple of 1/32768.
+            expect(truncateStatsValue('audioLevel', 0.00003051850947599719))
+                .to.equal(0.000030519);
+            // totalAudioEnergy with a tiny increment keeps its magnitude.
+            expect(truncateStatsValue('totalAudioEnergy', 0.0000000012345678))
+                .to.equal(0.0000000012346);
+        });
+
+        it('rounds Class C properties to 6 decimals', () => {
+            // jitter ~ multiples of 1/48000, too fine for millisecond rounding.
+            expect(truncateStatsValue('jitter', 0.0208333333333))
+                .to.equal(0.020833);
+        });
+
+        it('rounds Class D (default) properties to 3 decimals', () => {
+            expect(truncateStatsValue('totalSamplesDuration', 1.0000000000000007))
+                .to.equal(1);
+            expect(truncateStatsValue('totalDecodeTime', 0.1234567))
+                .to.equal(0.123);
+            expect(truncateStatsValue('currentRoundTripTime', 0.0123456789))
+                .to.equal(0.012);
+            expect(truncateStatsValue('roundTripTime', 0.15678))
+                .to.equal(0.157);
+            expect(truncateStatsValue('totalRoundTripTime', 12.34567))
+                .to.equal(12.346);
+            // An unknown float property also falls to the 3-decimal default.
+            expect(truncateStatsValue('googSomething', 0.98765))
+                .to.equal(0.988);
+        });
+    });
+
+    describe('truncateStatsReport', () => {
+        it('rounds every own numeric property in place and returns the object', () => {
+            const report = {
+                type: 'inbound-rtp',
+                timestamp: 1783323850971.656,
+                audioLevel: 0.00003051850947599719,
+                jitter: 0.0208333333333,
+                totalSamplesDuration: 1.0000000000000007,
+                packetsReceived: 100,
+                decoderImplementation: 'libvpx',
+            };
+            const returned = truncateStatsReport(report);
+            expect(returned).to.equal(report);
+            expect(report).to.deep.equal({
+                type: 'inbound-rtp',
+                timestamp: 1783323850972,
+                audioLevel: 0.000030519,
+                jitter: 0.020833,
+                totalSamplesDuration: 1,
+                packetsReceived: 100,
+                decoderImplementation: 'libvpx',
+            });
+        });
+
+        it('leaves nested object members untouched', () => {
+            const report = {
+                qualityLimitationDurations: {cpu: 1.5, none: 2.25},
+            };
+            truncateStatsReport(report);
+            expect(report.qualityLimitationDurations).to.deep.equal({cpu: 1.5, none: 2.25});
+        });
+    });
+});


### PR DESCRIPTION
getStats serializes doubles at full precision, so float noise like totalSamplesDuration:1.0000000000000007 or audioLevel at 1/32768 is paid on every getStats tick. Add a precision module to rtcstats-shared that rounds each double to a per-property precision (integer for epoch-ms timestamps and bitrates, 5 significant digits for audioLevel/ totalAudioEnergy, 6 decimals for jitter, 3 decimals otherwise) and apply it in rtcstats-js before the delta snapshot and compression.

Applied before the prevStats snapshot so base and current stay consistent: values shrink and values that only jitter below the precision threshold drop out of the delta entirely. On a sample audio+video dump the stats payload shrinks ~7.9%.

Lossy but not a wire-format change: only the producer rounds, decompression is untouched, old and new readers agree, no version bump.