### PR TITLE
js: fix missing __rtcStatsId on sendonly senders

### DIFF
--- a/packages/rtcstats-js/peerconnection.js
+++ b/packages/rtcstats-js/peerconnection.js
@@ -148,11 +148,6 @@ export function wrapRTCPeerConnection(trace, window, {getStatsInterval}) {
             e.track.addEventListener('mute', () => {
                 trace('MediaStreamTrack.onmute', pcId, e.track.id);
             });
-            if (e.transceiver) {
-                e.transceiver.__rtcStatsId = pcId;
-                e.transceiver.sender.__rtcStatsId = pcId;
-                e.transceiver.sender.__rtcStatsSenderId = e.track.id;
-            }
             if (e.track.kind === 'video' && window.document?.querySelectorAll) {
                 setTimeout(() => {
                     window.document.querySelectorAll('video').forEach(el => {
@@ -376,6 +371,11 @@ export function wrapRTCPeerConnection(trace, window, {getStatsInterval}) {
 
             return nativeMethod.apply(this, [description, ...args])
                 .then(() => {
+                    this.getTransceivers().forEach((transceiver) => {
+                        transceiver.__rtcStatsId = this.__rtcStatsId;
+                        transceiver.sender.__rtcStatsId = this.__rtcStatsId;
+                        transceiver.sender.__rtcStatsSenderId = transceiver.receiver.track.id;
+                    });
                     trace(method + 'OnSuccess', this.__rtcStatsId, undefined,
                         trackingId);
                 }, (err) => {

--- a/packages/rtcstats-js/test/e2e/peerconnection.js
+++ b/packages/rtcstats-js/test/e2e/peerconnection.js
@@ -371,6 +371,19 @@ describe('RTCPeerConnection', () => {
             expect(transceivers).to.have.length(1);
             expect(transceivers[0].__rtcStatsId).to.equal(pc.__rtcStatsId);
         });
+
+        it('sets ids on senders when ontrack does not fire (recvonly offer)', async () => {
+            pc = new RTCPeerConnection();
+            await pc.setRemoteDescription({type: 'offer', sdp: sdp.replace('a=sendonly', 'a=recvonly')});
+
+            const events = testSink.reset();
+            expect(events.find(e => e[0] === 'ontrack')).to.equal(undefined);
+
+            const transceiver = pc.getTransceivers()[0];
+            expect(transceiver.__rtcStatsId).to.equal(pc.__rtcStatsId);
+            expect(transceiver.sender.__rtcStatsId).to.equal(pc.__rtcStatsId);
+            expect(transceiver.sender.__rtcStatsSenderId).to.equal(transceiver.receiver.track.id);
+        });
     });
 
     describe('addTrack', () => {


### PR DESCRIPTION
for which ontrack never fires