### PR TITLE
server: reject empty uploads with a http 422 error

### DIFF
--- a/packages/rtcstats-features/features/client.js
+++ b/packages/rtcstats-features/features/client.js
@@ -86,7 +86,7 @@ function webSocketFeatures(clientTrace) {
 }
 
 // Client features related to the track (in case it is never added to a connection).
-function trackFeatures(clientTrace, kind) {
+function trackFeatures(clientTrace) {
     const features = {};
     const allTracks = {};
     for (const traceEvent of clientTrace) {

--- a/packages/rtcstats-server/rtcstats-upload.js
+++ b/packages/rtcstats-server/rtcstats-upload.js
@@ -119,6 +119,15 @@ export async function handleFileupload(clientId, request, response, writeStream)
         return;
     }
 
+    if (extractor.numberOfMessages === 0) {
+        response.writeHead(422, { 'Content-Type': 'text/plain' });
+        response.end('Unprocessable Entity: the uploaded dump contained no messages');
+        return {
+            numberOfMessages: 0,
+            metadata: extractor.metadata,
+        };
+    }
+
     response.writeHead(200, { 'Content-Type': 'application/json' });
     response.end(JSON.stringify({ message: 'Upload successful', clientId }));
     return {

--- a/packages/rtcstats-server/test/rtcstats-server.js
+++ b/packages/rtcstats-server/test/rtcstats-server.js
@@ -133,6 +133,27 @@ describe('RTCStatsServer', () => {
             expect(result.status).to.equal(400);
             await server.close();
         });
+        it('rejects a http upload without any messages', async() => {
+            const conf = structuredClone(baseConfig);
+            conf.authorization = {};
+            conf.server.httpUploadPath = '/upload';
+            server = new RTCStatsServer(conf);
+            await server.listen();
+
+            const emptyBlob = new Blob([
+                'RTCStatsDump\n' +
+                '{"fileFormat":3}\n'
+            ], {type: 'application/jsonl'});
+            const formData = new FormData();
+            formData.append('dump', emptyBlob, 'test.jsonl');
+            const result = await fetch('http://localhost:' + conf.server.httpPort + '/upload', {
+                method: 'POST',
+                body: formData,
+            });
+            expect(result.ok).to.be.false;
+            expect(result.status).to.equal(422);
+            await server.close();
+        });
         it('accepts a valid http upload', async () => {
             const conf = structuredClone(baseConfig);
             conf.authorization = {};


### PR DESCRIPTION
similar to how websocket (silently) drops