### PR TITLE
features: add custom feature extraction framework

### DIFF
--- a/packages/rtcstats-features/features.md
+++ b/packages/rtcstats-features/features.md
@@ -6,6 +6,10 @@ This document describes the features extracted by the three feature extractors i
 * [`connection.js`](./features/connection.js): `extractConnectionFeatures(clientTrace, peerConnectionTrace)`
 * [`track.js`](./features/track.js): `extractTrackFeatures(clientTrace, peerConnectionTrace, trackInformation)`
 
+Deployment-specific features go into [`custom.js`](./features/custom.js), which each of the three
+extractors calls and merges into its result. Custom feature names must start with `custom` and the
+matching database columns are the responsibility of the deployment, see the file for details.
+
 ## Relationship between client, connection and track features
 
 A single rtcstats dump consists of a `clientTrace` (events not associated with any peer connection,

--- a/packages/rtcstats-features/features/client.js
+++ b/packages/rtcstats-features/features/client.js
@@ -1,4 +1,5 @@
 /* eslint sort-keys: "error" */
+import {extractCustomClientFeatures} from './custom.js';
 
 /* Client features are features that describe the client, independent of a particular peerconnection.
  * They are calculated based on the clientTrace, i.e. the events that are not associated with a
@@ -125,6 +126,7 @@ export function extractClientFeatures(clientTrace) {
         startTime: clientTrace[0].timestamp,
         ...trackFeatures(clientTrace),
         ...webSocketFeatures(clientTrace),
+        ...extractCustomClientFeatures(clientTrace),
     };
 }
 

--- a/packages/rtcstats-features/features/client.js
+++ b/packages/rtcstats-features/features/client.js
@@ -1,4 +1,5 @@
 /* eslint sort-keys: "error" */
+import {extractCustomClientFeatures} from './custom.js';
 
 /* Client features are features that describe the client, independent of a particular peerconnection.
  * They are calculated based on the clientTrace, i.e. the events that are not associated with a
@@ -149,6 +150,7 @@ export function extractClientFeatures(clientTrace) {
         startTime: clientTrace[0].timestamp,
         ...trackFeatures(clientTrace),
         ...webSocketFeatures(clientTrace),
+        ...extractCustomClientFeatures(clientTrace),
     };
 }
 

--- a/packages/rtcstats-features/features/connection.js
+++ b/packages/rtcstats-features/features/connection.js
@@ -2,6 +2,7 @@
 import SDPUtils from 'sdp';
 
 import {divideStat, pluckStat} from '../statUtils.js';
+import {extractCustomConnectionFeatures} from './custom.js';
 
 function getSelectedCandidatePairStats(report) {
     const transportId = Object.keys(report).find(id => {
@@ -504,7 +505,7 @@ function signalingDelay(/* clientTrace*/_, peerConnectionTrace) {
     return peerConnectionTrace[second].timestamp - peerConnectionTrace[first].timestamp;
 }
 
-export function extractConnectionFeatures(/* clientTrace*/_, peerConnectionTrace) {
+export function extractConnectionFeatures(clientTrace, peerConnectionTrace) {
     // A trace will always have at least one event.
     return {
         ... apiFailures(undefined, peerConnectionTrace),
@@ -529,5 +530,6 @@ export function extractConnectionFeatures(/* clientTrace*/_, peerConnectionTrace
         signalingDelay: signalingDelay(undefined, peerConnectionTrace),
         // The timestamp at which the peer connection was created.
         startTime: peerConnectionTrace[0].timestamp,
+        ... extractCustomConnectionFeatures(clientTrace, peerConnectionTrace),
     };
 }

--- a/packages/rtcstats-features/features/connection.js
+++ b/packages/rtcstats-features/features/connection.js
@@ -2,6 +2,7 @@
 import SDPUtils from 'sdp';
 
 import {divideStat, pluckStat} from '../statUtils.js';
+import {extractCustomConnectionFeatures} from './custom.js';
 
 function getSelectedTransportStats(report) {
     const transportId = Object.keys(report).find(id => {
@@ -572,7 +573,7 @@ function statsTruncated(/* clientTrace*/_, peerConnectionTrace) {
         firstSeen[id] - peerConnectionTrace[0].timestamp > 60000);
 }
 
-export function extractConnectionFeatures(/* clientTrace*/_, peerConnectionTrace) {
+export function extractConnectionFeatures(clientTrace, peerConnectionTrace) {
     // A trace will always have at least one event.
     return {
         ... apiFailures(undefined, peerConnectionTrace),
@@ -598,5 +599,6 @@ export function extractConnectionFeatures(/* clientTrace*/_, peerConnectionTrace
         // The timestamp at which the peer connection was created.
         startTime: peerConnectionTrace[0].timestamp,
         statsTruncated: statsTruncated(undefined, peerConnectionTrace),
+        ... extractCustomConnectionFeatures(clientTrace, peerConnectionTrace),
     };
 }

--- a/packages/rtcstats-features/features/custom.js
+++ b/packages/rtcstats-features/features/custom.js
@@ -1,0 +1,48 @@
+/* eslint sort-keys: "error" */
+
+/* Custom feature extraction.
+ *
+ * This file is the place for deployment-specific features. It ships nearly empty and is
+ * intentionally never touched by updates to this repository, so rebasing or merging a new
+ * upstream version on top of a customized deployment should not conflict here.
+ *
+ * There are three extractors, mirroring the three built-in ones in this directory:
+ *   extractCustomClientFeatures(clientTrace), called by `client.js`
+ *   extractCustomConnectionFeatures(clientTrace, peerConnectionTrace), called by `connection.js`
+ *   extractCustomTrackFeatures(clientTrace, peerConnectionTrace, trackInformation), called by `track.js`
+ *
+ * Each returns an object which is merged into the row inserted into `features_client`,
+ * `features_connection` and `features_track` respectively. Returning an empty object
+ * (the default) means no custom columns are written.
+ *
+ * Rules:
+ *
+ * 1. Every key MUST start with `custom`, e.g. `customConferenceId` or `customSfuRegion`.
+ *    This keeps upstream free to add features without ever colliding with a custom one.
+ *
+ * 2. You are responsible for your own database migrations. Adding a key here does not
+ *    create the column. Add a migration under `supabase/migrations/` creating the
+ *    corresponding snake_case column (`customSfuRegion` becomes `custom_sfu_region`)
+ *    on the right table, or the insert will fail.
+ *
+ * 3. Extractors must not throw and must be synchronous. Return `undefined` for a feature
+ *    that does not apply to a given dump rather than throwing.
+ *
+ * See `../features.md` for the shape of `clientTrace`, `peerConnectionTrace` and
+ * `trackInformation`, and the other files in this directory for examples.
+ */
+
+// Features describing the client as a whole, extracted from the clientTrace.
+export function extractCustomClientFeatures(/* clientTrace */_) {
+    return {};
+}
+
+// Features describing a single RTCPeerConnection.
+export function extractCustomConnectionFeatures(/* clientTrace */_, /* peerConnectionTrace */__) {
+    return {};
+}
+
+// Features describing a single inbound or outbound media track of a connection.
+export function extractCustomTrackFeatures(/* clientTrace */_, /* peerConnectionTrace */__, /* trackInformation */___) {
+    return {};
+}

--- a/packages/rtcstats-features/features/track.js
+++ b/packages/rtcstats-features/features/track.js
@@ -4,6 +4,7 @@ import SDPUtils from 'sdp';
 import {parseTrackWithStreams} from '@rtcstats/rtcstats-shared';
 
 import {divideStat, pluckStat} from '../statUtils.js';
+import {extractCustomTrackFeatures} from './custom.js';
 
 function codecFeatures(/* clientTrace*/_, peerConnectionTrace, trackInformation) {
     for (const traceEvent of peerConnectionTrace) {
@@ -205,7 +206,7 @@ function lastStatsFeatures(/* clientTrace*/_, peerConnectionTrace, trackInformat
     return features;
 }
 
-export function extractTrackFeatures(/* clientTrace*/_, peerConnectionTrace, trackInformation) {
+export function extractTrackFeatures(clientTrace, peerConnectionTrace, trackInformation) {
     // Track stats can be extracted by iterating over peerConnectionTrace and looking at
     // getStats events which are associated with trackInformation.statsId.
     const features = {
@@ -222,5 +223,6 @@ export function extractTrackFeatures(/* clientTrace*/_, peerConnectionTrace, tra
         ...resolutionFeatures(undefined, peerConnectionTrace, trackInformation),
         ...audioJitterBufferFeatures(undefined, peerConnectionTrace, trackInformation),
         ...lastStatsFeatures(undefined, peerConnectionTrace, trackInformation),
+        ...extractCustomTrackFeatures(clientTrace, peerConnectionTrace, trackInformation),
     };
 }

--- a/packages/rtcstats-features/features/track.js
+++ b/packages/rtcstats-features/features/track.js
@@ -4,6 +4,7 @@ import SDPUtils from 'sdp';
 import {parseTrackWithStreams} from '@rtcstats/rtcstats-shared';
 
 import {divideStat, pluckStat} from '../statUtils.js';
+import {extractCustomTrackFeatures} from './custom.js';
 
 function codecFeatures(/* clientTrace*/_, peerConnectionTrace, trackInformation) {
     for (const traceEvent of peerConnectionTrace) {
@@ -218,7 +219,7 @@ function lastStatsFeatures(/* clientTrace*/_, peerConnectionTrace, trackInformat
     return features;
 }
 
-export function extractTrackFeatures(/* clientTrace*/_, peerConnectionTrace, trackInformation) {
+export function extractTrackFeatures(clientTrace, peerConnectionTrace, trackInformation) {
     // Track stats can be extracted by iterating over peerConnectionTrace and looking at
     // getStats events which are associated with trackInformation.statsId.
     const features = {
@@ -236,5 +237,6 @@ export function extractTrackFeatures(/* clientTrace*/_, peerConnectionTrace, tra
         ...resolutionFeatures(undefined, peerConnectionTrace, trackInformation),
         ...audioJitterBufferFeatures(undefined, peerConnectionTrace, trackInformation),
         ...lastStatsFeatures(undefined, peerConnectionTrace, trackInformation),
+        ...extractCustomTrackFeatures(clientTrace, peerConnectionTrace, trackInformation),
     };
 }


### PR DESCRIPTION
with a file `custom.js` that implements client, connection and track-based feature extraction with fields that are, by convention, returning features names start with `custom`. This maps to database fields with a `custom_` prefix and avoids collisions with standard features.

Changes to custom.js will be rare so merge conflicts can be largely avoided