### PR TITLE
features: index the features foreign key database columns

### DIFF
--- a/supabase/migrations/20260722110000_add_indexes_on_features_foreign_keys.sql
+++ b/supabase/migrations/20260722110000_add_indexes_on_features_foreign_keys.sql
@@ -1,0 +1,7 @@
+create index "features_metadata_dump_id_idx" on "public"."features_metadata" ("dump_id");
+
+create index "features_client_dump_id_idx" on "public"."features_client" ("dump_id");
+
+create index "features_connection_dump_id_idx" on "public"."features_connection" ("dump_id");
+
+create index "features_track_connection_id_idx" on "public"."features_track" ("connection_id");


### PR DESCRIPTION
The features tables declare four foreign keys but only ever created the primary key indexes, leaving the referencing columns unindexed. Postgres does not index the referencing side automatically, so cascading deletes and dump_id/connection_id lookups fall back to sequential scans.