### PR TITLE
config: change default dotcom endpoint

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -64,7 +64,7 @@ database:
 # Integration with rtcstats.com
 rtcstats:
     # rtcstats.com public endpoint.
-    endpoint: https://rtcstats.com/api/rtcstats/v1.0/upload
+    endpoint: https://api.rtcstats.com/v1.0/upload
     # rtcstats.com token needs to be configured.
     token:
     # If set to a number between 0 and 1 a random percentage of dumps will be uploaded.


### PR DESCRIPTION
which now resides on api.rtcstats.com (but the old url continues to work)

f'up to #308