### PR TITLE
shared: list the client-level connection first when reading a dump

### DIFF
--- a/packages/rtcstats-shared/dump.js
+++ b/packages/rtcstats-shared/dump.js
@@ -36,7 +36,8 @@ export async function readRTCStatsDump(blob) {
         console.error('Second line must be an object');
         return;
     }
-    data.peerConnections = {};
+    // Ensure the client-level connection is listed before the peer connections.
+    data.peerConnections = {null: []};
     data.eventSizes = {};
 
     const baseStats = {};
@@ -115,6 +116,9 @@ export async function readRTCStatsDump(blob) {
             y: line.length,
             method,
         });
+    }
+    if (!data.peerConnections['null'].length) {
+        delete data.peerConnections['null'];
     }
     return data;
 }

--- a/packages/rtcstats-shared/test/dump.js
+++ b/packages/rtcstats-shared/test/dump.js
@@ -43,6 +43,16 @@ describe('RTCStats dump', () => {
             });
         });
 
+        it('lists the client-level connection first', async () => {
+            const blob = new Blob(['RTCStatsDump\n' +
+                JSON.stringify({fileFormat: 3}) + '\n' +
+                JSON.stringify(['create', 'PC_0', {}, 1]) + '\n' +
+                JSON.stringify(['navigator.mediaDevices.getUserMedia', null, {audio: true}, 1]) + '\n'
+            ]);
+            const result = await readRTCStatsDump(blob);
+            expect(Object.keys(result.peerConnections)).to.deep.equal(['null', 'PC_0']);
+        });
+
         it('ignores other formats', async () => {
             const blob = new Blob(['Not an RTCStatsDump\n']);
             const result = await readRTCStatsDump(blob);


### PR DESCRIPTION
which makes the dump-importer display order more consistent