### PR TITLE
shared: unquote state values in dumps written by Chrome

### DIFF
--- a/packages/rtcstats-shared/dump.js
+++ b/packages/rtcstats-shared/dump.js
@@ -6,6 +6,41 @@ import {
 import {createInternalsTimeSeries} from './timeseries.js';
 import {parseTrackWithStreams} from './utils.js';
 
+// Chrome JSON-encodes the state in these events, rtcstats-js writes it bare.
+// https://chromium-review.googlesource.com/c/chromium/src/+/6917903
+const STATE_VALUES = {
+    onsignalingstatechange: {
+        '"stable"': 'stable',
+        '"have-local-offer"': 'have-local-offer',
+        '"have-remote-offer"': 'have-remote-offer',
+        '"have-local-pranswer"': 'have-local-pranswer',
+        '"have-remote-pranswer"': 'have-remote-pranswer',
+        '"closed"': 'closed',
+    },
+    oniceconnectionstatechange: {
+        '"new"': 'new',
+        '"checking"': 'checking',
+        '"connected"': 'connected',
+        '"completed"': 'completed',
+        '"failed"': 'failed',
+        '"disconnected"': 'disconnected',
+        '"closed"': 'closed',
+    },
+    onconnectionstatechange: {
+        '"new"': 'new',
+        '"connecting"': 'connecting',
+        '"connected"': 'connected',
+        '"disconnected"': 'disconnected',
+        '"failed"': 'failed',
+        '"closed"': 'closed',
+    },
+    onicegatheringstatechange: {
+        '"new"': 'new',
+        '"gathering"': 'gathering',
+        '"complete"': 'complete',
+    },
+};
+
 export async function detectRTCStatsDump(blob) {
     const magic = await blob.slice(0, 13).text();
     return magic.startsWith('RTCStatsDump\n');
@@ -61,6 +96,8 @@ export async function readRTCStatsDump(blob) {
 
         lastTime = extra.pop() + lastTime;
         const time = new Date(lastTime);
+
+        value = STATE_VALUES[method]?.[value] || value;
 
         if (method === 'getStats') { // delta-compressed stats
             // statsDecompression does not modify its base stats argument.

--- a/packages/rtcstats-shared/test/dump.js
+++ b/packages/rtcstats-shared/test/dump.js
@@ -191,6 +191,47 @@ describe('RTCStats dump', () => {
                 }]},
             });
         });
+
+        // Chrome's own rtcstats writer JSON-encodes state-change values.
+        // Frames taken from a real dump, connection 18-4.
+        describe('state changes written by Chrome', () => {
+            const chromeDump = ['RTCStatsDump\n' +
+                JSON.stringify({fileFormat: 3}) + '\n' +
+                '["onsignalingstatechange","18-4","\\"have-local-offer\\"",1]\n' +
+                '["onicegatheringstatechange","18-4","\\"gathering\\"",1]\n' +
+                '["oniceconnectionstatechange","18-4","\\"checking\\"",1]\n' +
+                '["onconnectionstatechange","18-4","\\"connecting\\"",1]\n' +
+                '["oniceconnectionstatechange","18-4","\\"connected\\"",1]\n' +
+                '["onconnectionstatechange","18-4","\\"connected\\"",1]\n'
+            ];
+
+            it('unwraps the JSON-encoded state', async () => {
+                const result = await readRTCStatsDump(new Blob(chromeDump));
+                expect(result.peerConnections['18-4'].map(e => e.value)).to.deep.equal([
+                    'have-local-offer', 'gathering', 'checking', 'connecting', 'connected', 'connected',
+                ]);
+            });
+
+            it('leaves bare state values written by rtcstats-js alone', async () => {
+                const blob = new Blob(['RTCStatsDump\n' +
+                    JSON.stringify({fileFormat: 3}) + '\n' +
+                    JSON.stringify(['oniceconnectionstatechange', 'PC_0', 'checking', 1]) + '\n' +
+                    JSON.stringify(['onconnectionstatechange', 'PC_0', 'connected', 1]) + '\n'
+                ]);
+                const result = await readRTCStatsDump(blob);
+                expect(result.peerConnections['PC_0'].map(e => e.value))
+                    .to.deep.equal(['checking', 'connected']);
+            });
+
+            it('leaves quoted values that are not state names alone', async () => {
+                const blob = new Blob(['RTCStatsDump\n' +
+                    JSON.stringify({fileFormat: 3}) + '\n' +
+                    JSON.stringify(['createOfferOnFailure', 'PC_0', '"NotSupportedError"', 1]) + '\n'
+                ]);
+                const result = await readRTCStatsDump(blob);
+                expect(result.peerConnections['PC_0'][0].value).to.equal('"NotSupportedError"');
+            });
+        });
     });
 
     describe('extractTracks', () => {


### PR DESCRIPTION
Chrome JSON-encodes the value of the four peer connection state change events, so the state arrives with its own quotes and every feature comparing it against a bare string literal reads the connection as having never connected.

See
https://chromium-review.googlesource.com/c/chromium/src/+/6917903