### PR TITLE
features: compute average bitrates and stun rtt across candidate pairs

### DIFF
--- a/packages/rtcstats-features/features.md
+++ b/packages/rtcstats-features/features.md
@@ -251,13 +251,13 @@ All fields below come from the first `getStats` report taken after `onconnection
 
 ### Last-stats averages
 
-Computed from the selected [`RTCIceCandidatePairStats`](https://w3c.github.io/webrtc-stats/#candidatepair-dict*).
+Averages over the connection's lifetime.
 
 | Feature | Type | Source | Description |
 | --- | --- | --- | --- |
-| `averageStunRoundTripTime` | number | last getStats ratio | Average STUN RTT over the connection's lifetime ([`totalRoundTripTime`](https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-totalroundtriptime) / [`responsesReceived`](https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-responsesreceived) on the selected candidate pair). |
-| `averageOutboundBitrate` | number | last getStats ratio | Average outbound bitrate (bits/s) over the connection's lifetime: `(last.bytesSent - first.bytesSent) * 8 / (last.timestamp - first.timestamp)` on the selected candidate pair, where `first` is the earliest `getStats` report whose selected pair has non-zero `bytesSent` and `bytesReceived`. |
-| `averageInboundBitrate` | number | last getStats ratio | Average inbound bitrate (bits/s) over the connection's lifetime: `(last.bytesReceived - first.bytesReceived) * 8 / (last.timestamp - first.timestamp)` on the selected candidate pair, with `first` defined as for `averageOutboundBitrate`. |
+| `averageStunRoundTripTime` | number | last getStats ratio | Average STUN RTT, summing [`totalRoundTripTime`](https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-totalroundtriptime) and [`responsesReceived`](https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-responsesreceived) per selected [candidate pair](https://w3c.github.io/webrtc-stats/#candidatepair-dict*) since those counters restart when the selected pair changes. |
+| `averageOutboundBitrate` | number | last getStats ratio | Average outbound bitrate from the [transport's](https://w3c.github.io/webrtc-stats/#transportstats-dict*) [`bytesSent`](https://w3c.github.io/webrtc-stats/#dom-rtctransportstats-bytessent), between the first `getStats` report with non-zero bytes and the last. |
+| `averageInboundBitrate` | number | last getStats ratio | Average inbound bitrate from the transport's [`bytesReceived`](https://w3c.github.io/webrtc-stats/#dom-rtctransportstats-bytesreceived), over the same interval. |
 
 ### Geolocation
 

--- a/packages/rtcstats-features/features/connection.js
+++ b/packages/rtcstats-features/features/connection.js
@@ -3,7 +3,7 @@ import SDPUtils from 'sdp';
 
 import {divideStat, pluckStat} from '../statUtils.js';
 
-function getSelectedCandidatePairStats(report) {
+function getSelectedTransportStats(report) {
     const transportId = Object.keys(report).find(id => {
         const stats = report[id];
         // Spec.
@@ -13,9 +13,13 @@ function getSelectedCandidatePairStats(report) {
         return report.type === 'candidate-pair' && report.selected === true;
         */
     });
-    if (transportId) {
-        const {selectedCandidatePairId} = report[transportId];
-        return report[selectedCandidatePairId];
+    return transportId ? report[transportId] : undefined;
+}
+
+function getSelectedCandidatePairStats(report) {
+    const transportStats = getSelectedTransportStats(report);
+    if (transportStats) {
+        return report[transportStats.selectedCandidatePairId];
     }
     return undefined;
 }
@@ -383,30 +387,42 @@ function lastStatsFeatures(/* clientTrace*/_, peerConnectionTrace) {
     const features = {};
     let lastStatsEvent;
     let lastCandidatePairStats;
+    let lastTransportStats;
     let firstStatsEvent;
-    let firstCandidatePairStats;
+    let firstTransportStats;
+    const selectedCandidatePairs = new Map();
     for (let i = 0; i < peerConnectionTrace.length; i++) {
         const traceEvent = peerConnectionTrace[i];
         if (traceEvent.type !== 'getStats' || !traceEvent.value) continue;
-        const candidatePairStats = getSelectedCandidatePairStats(traceEvent.value);
+        const transportStats = getSelectedTransportStats(traceEvent.value);
+        if (!transportStats) continue;
+        const candidatePairStats = traceEvent.value[transportStats.selectedCandidatePairId];
         if (!candidatePairStats) continue;
         lastStatsEvent = traceEvent;
         lastCandidatePairStats = candidatePairStats;
+        lastTransportStats = transportStats;
+        selectedCandidatePairs.set(transportStats.selectedCandidatePairId, candidatePairStats);
+        // Byte counters come from the transport, not the candidate-pair which changes after an ice restart.
         if (!firstStatsEvent &&
-            pluckStat(candidatePairStats, ['bytesSent']) > 0 &&
-            pluckStat(candidatePairStats, ['bytesReceived']) > 0) {
+            pluckStat(transportStats, ['bytesSent']) > 0 &&
+            pluckStat(transportStats, ['bytesReceived']) > 0) {
             firstStatsEvent = traceEvent;
-            firstCandidatePairStats = candidatePairStats;
+            firstTransportStats = transportStats;
         }
     }
     if (!(lastStatsEvent && lastCandidatePairStats)) {
         return features;
     }
-    features['averageStunRoundTripTime'] = divideStat(lastCandidatePairStats, 'totalRoundTripTime', 'responsesReceived');
+    const roundTripTimeTotals = {responsesReceived: 0, totalRoundTripTime: 0};
+    for (const candidatePairStats of selectedCandidatePairs.values()) {
+        roundTripTimeTotals.responsesReceived += pluckStat(candidatePairStats, ['responsesReceived']) || 0;
+        roundTripTimeTotals.totalRoundTripTime += pluckStat(candidatePairStats, ['totalRoundTripTime']) || 0;
+    }
+    features['averageStunRoundTripTime'] = divideStat(roundTripTimeTotals, 'totalRoundTripTime', 'responsesReceived');
     if (firstStatsEvent && firstStatsEvent.timestamp < lastStatsEvent.timestamp) {
         const deltaSeconds = (lastStatsEvent.timestamp - firstStatsEvent.timestamp) / 1000;
-        features['averageOutboundBitrate'] = ((pluckStat(lastCandidatePairStats, ['bytesSent']) - pluckStat(firstCandidatePairStats, ['bytesSent'])) * 8) / deltaSeconds;
-        features['averageInboundBitrate'] = ((pluckStat(lastCandidatePairStats, ['bytesReceived']) - pluckStat(firstCandidatePairStats, ['bytesReceived'])) * 8) / deltaSeconds;
+        features['averageOutboundBitrate'] = ((pluckStat(lastTransportStats, ['bytesSent']) - pluckStat(firstTransportStats, ['bytesSent'])) * 8) / deltaSeconds;
+        features['averageInboundBitrate'] = ((pluckStat(lastTransportStats, ['bytesReceived']) - pluckStat(firstTransportStats, ['bytesReceived'])) * 8) / deltaSeconds;
     }
     return features;
 }

--- a/packages/rtcstats-features/test/connection.js
+++ b/packages/rtcstats-features/test/connection.js
@@ -610,6 +610,30 @@ describe('extractConnectionFeatures', () => {
         expect(features.averageOutboundBitrate).to.be.undefined;
     });
 
+    it('should extract the stun round trip time across a change of the selected candidate pair', () => {
+        const pcTrace = [
+            {
+                type: 'getStats',
+                value: {
+                    1: { type: 'transport', selectedCandidatePairId: '2' },
+                    2: { type: 'candidate-pair', totalRoundTripTime: 100, responsesReceived: 2 },
+                },
+                timestamp: 1001,
+            },
+            {
+                type: 'getStats',
+                value: {
+                    1: { type: 'transport', selectedCandidatePairId: '3' },
+                    2: { type: 'candidate-pair', totalRoundTripTime: 100, responsesReceived: 2 },
+                    3: { type: 'candidate-pair', totalRoundTripTime: 20, responsesReceived: 2 },
+                },
+                timestamp: 2001,
+            },
+        ];
+        const features = extractConnectionFeatures([], pcTrace);
+        expect(features.averageStunRoundTripTime).to.equal(30);
+    });
+
     it('should not divide by zero when no STUN responses were received', () => {
         const pcTrace = [
             {
@@ -630,24 +654,24 @@ describe('extractConnectionFeatures', () => {
             {
                 type: 'getStats',
                 value: {
-                    1: { type: 'transport', selectedCandidatePairId: '2' },
-                    2: { type: 'candidate-pair', bytesSent: 0, bytesReceived: 0 },
+                    1: { type: 'transport', selectedCandidatePairId: '2', bytesSent: 0, bytesReceived: 0 },
+                    2: { type: 'candidate-pair' },
                 },
                 timestamp: 1000,
             },
             {
                 type: 'getStats',
                 value: {
-                    1: { type: 'transport', selectedCandidatePairId: '2' },
-                    2: { type: 'candidate-pair', bytesSent: 1000, bytesReceived: 2000 },
+                    1: { type: 'transport', selectedCandidatePairId: '2', bytesSent: 1000, bytesReceived: 2000 },
+                    2: { type: 'candidate-pair' },
                 },
                 timestamp: 5000,
             },
             {
                 type: 'getStats',
                 value: {
-                    1: { type: 'transport', selectedCandidatePairId: '2' },
-                    2: { type: 'candidate-pair', bytesSent: 5000, bytesReceived: 10000 },
+                    1: { type: 'transport', selectedCandidatePairId: '2', bytesSent: 5000, bytesReceived: 10000 },
+                    2: { type: 'candidate-pair' },
                 },
                 timestamp: 9000,
             },
@@ -658,21 +682,80 @@ describe('extractConnectionFeatures', () => {
         expect(features.averageInboundBitrate).to.equal((10000 - 2000) * 8 / 4);
     });
 
-    it('should not extract bitrate when there is only one non-zero stats event', () => {
+    it('should extract average bitrate across a change of the selected candidate pair', () => {
         const pcTrace = [
             {
                 type: 'getStats',
                 value: {
-                    1: { type: 'transport', selectedCandidatePairId: '2' },
-                    2: { type: 'candidate-pair', bytesSent: 0, bytesReceived: 0 },
+                    1: { type: 'transport', selectedCandidatePairId: '2', bytesSent: 1000, bytesReceived: 2000 },
+                    2: { type: 'candidate-pair', bytesSent: 1000, bytesReceived: 2000 },
                 },
                 timestamp: 1000,
             },
             {
                 type: 'getStats',
                 value: {
-                    1: { type: 'transport', selectedCandidatePairId: '2' },
+                    1: { type: 'transport', selectedCandidatePairId: '2', bytesSent: 5000, bytesReceived: 10000 },
+                    2: { type: 'candidate-pair', bytesSent: 5000, bytesReceived: 10000 },
+                },
+                timestamp: 5000,
+            },
+            {
+                // The ice restart selects a new pair whose own counters start at zero.
+                type: 'getStats',
+                value: {
+                    1: { type: 'transport', selectedCandidatePairId: '3', bytesSent: 9000, bytesReceived: 18000 },
+                    2: { type: 'candidate-pair', bytesSent: 5000, bytesReceived: 10000 },
+                    3: { type: 'candidate-pair', bytesSent: 4000, bytesReceived: 8000 },
+                },
+                timestamp: 9000,
+            },
+        ];
+        const features = extractConnectionFeatures([], pcTrace);
+        expect(features.averageOutboundBitrate).to.equal((9000 - 1000) * 8 / 8);
+        expect(features.averageInboundBitrate).to.equal((18000 - 2000) * 8 / 8);
+    });
+
+    it('should extract a positive bitrate when the new candidate pair sends nothing', () => {
+        const pcTrace = [
+            {
+                type: 'getStats',
+                value: {
+                    1: { type: 'transport', selectedCandidatePairId: '2', bytesSent: 1000, bytesReceived: 2000 },
                     2: { type: 'candidate-pair', bytesSent: 1000, bytesReceived: 2000 },
+                },
+                timestamp: 1000,
+            },
+            {
+                type: 'getStats',
+                value: {
+                    1: { type: 'transport', selectedCandidatePairId: '3', bytesSent: 5000, bytesReceived: 10000 },
+                    2: { type: 'candidate-pair', bytesSent: 5000, bytesReceived: 10000 },
+                    3: { type: 'candidate-pair', bytesSent: 0, bytesReceived: 0 },
+                },
+                timestamp: 5000,
+            },
+        ];
+        const features = extractConnectionFeatures([], pcTrace);
+        expect(features.averageOutboundBitrate).to.equal((5000 - 1000) * 8 / 4);
+        expect(features.averageInboundBitrate).to.equal((10000 - 2000) * 8 / 4);
+    });
+
+    it('should not extract bitrate when there is only one non-zero stats event', () => {
+        const pcTrace = [
+            {
+                type: 'getStats',
+                value: {
+                    1: { type: 'transport', selectedCandidatePairId: '2', bytesSent: 0, bytesReceived: 0 },
+                    2: { type: 'candidate-pair' },
+                },
+                timestamp: 1000,
+            },
+            {
+                type: 'getStats',
+                value: {
+                    1: { type: 'transport', selectedCandidatePairId: '2', bytesSent: 1000, bytesReceived: 2000 },
+                    2: { type: 'candidate-pair' },
                 },
                 timestamp: 5000,
             },


### PR DESCRIPTION
The candidate-pair byte counters restart at zero when the selected pair
changes (e.g. because of an ice restart), which made the averages
understate the bitrate or go negative. Take the byte counters from the
transport instead, which keeps counting across a change of the selected
pair, and pick the first report whose transport has non-zero bytesSent
and bytesReceived as the start of the interval.

totalRoundTripTime and responsesReceived have the same problem but are
not available on the transport, so sum them over every candidate pair
that was selected at some point during the connection instead of reading
them from the last one only.

Shorten the descriptions of the three features in features.md.
