### PR TITLE
features: extract the USB id of the getUserMedia devices

### DIFF
--- a/packages/rtcstats-features/features.md
+++ b/packages/rtcstats-features/features.md
@@ -101,6 +101,8 @@ Any other fields present on the `create` event's `value` are also spread into th
 | `getUserMediaError` | string | first event | Error name/value of the first failed `getUserMedia`. |
 | `getUserMediaErrorCount` | number | count | Number of failed `getUserMedia` calls. |
 | `getUserMediaSuccessCount` | number | count | Number of successful `getUserMedia` calls. |
+| `audioDeviceUsbId` | string | first event | USB `vendor:product` id of the first audio device acquired via `getUserMedia`. |
+| `videoDeviceUsbId` | string | first event | USB `vendor:product` id of the first video device acquired via `getUserMedia`. |
 
 ### `getDisplayMedia`
 

--- a/packages/rtcstats-features/features/client.js
+++ b/packages/rtcstats-features/features/client.js
@@ -5,9 +5,30 @@
  * connection such as getUserMedia or enumerateDevices.
  */
 
+// The USB id of the first device of that kind acquired via getUserMedia.
+// Labels of USB devices end with the vendor:product id, e.g. "Logitech BRIO (046d:085e)".
+function deviceUsbId(clientTrace, kind) {
+    for (const traceEvent of clientTrace) {
+        if (traceEvent.type !== 'navigator.mediaDevices.getUserMediaOnSuccess') {
+            continue;
+        }
+        for (const track of traceEvent.value) {
+            const label = track[2] || '';
+            if (track[0] !== kind || !label.endsWith(')')) {
+                continue;
+            }
+            const usbId = label.slice(-10, -1);
+            if (usbId[4] === ':') {
+                return usbId;
+            }
+        }
+    }
+}
+
 // Client features related to getUserMedia.
 function getUserMediaFeatures(clientTrace) {
     return {
+        audioDeviceUsbId: deviceUsbId(clientTrace, 'audio'),
         calledGetUserMedia: clientTrace.find(traceEvent => {
             // Whether getUserMedia was called at least once.
             return traceEvent.type === 'navigator.mediaDevices.getUserMedia';
@@ -37,6 +58,7 @@ function getUserMediaFeatures(clientTrace) {
             // The number of successful getUserMedia calls.
             return traceEvent.type === 'navigator.mediaDevices.getUserMediaOnSuccess';
         }).length,
+        videoDeviceUsbId: deviceUsbId(clientTrace, 'video'),
     };
 }
 

--- a/packages/rtcstats-features/test/client.js
+++ b/packages/rtcstats-features/test/client.js
@@ -5,7 +5,7 @@ describe('extractClientFeatures', () => {
         const clientTrace = [
             { type: 'create', value: { startTime: 1000, duration: 500, userAgentData: 'ua', hardwareConcurrency: 4, deviceMemory: 8, cpuPerformance: 3, screen: 'screen', window: 'window', reloadCount: 3 }, timestamp: 1000 },
             { type: 'navigator.mediaDevices.getUserMedia', value: { audio: true, video: false }, timestamp: 1001 },
-            { type: 'navigator.mediaDevices.getUserMediaOnSuccess', value: [], timestamp: 1002 },
+            { type: 'navigator.mediaDevices.getUserMediaOnSuccess', value: [['audio', 'audio-id', 'ACME mic (0000:0000)', 'stream-id']], timestamp: 1002 },
             { type: 'navigator.mediaDevices.getDisplayMedia', value: { video: true }, timestamp: 1003 },
             { type: 'navigator.mediaDevices.getDisplayMediaOnSuccess', value: [], timestamp: 1004 },
             { type: 'navigator.mediaDevices.enumerateDevices', timestamp: 1005 },
@@ -26,6 +26,8 @@ describe('extractClientFeatures', () => {
             reloadCount: 3,
             operatingSystem: undefined,
             webSocketConnectionTime: undefined,
+            audioDeviceUsbId: '0000:0000',
+            videoDeviceUsbId: undefined,
             calledGetUserMedia: true,
             calledGetUserMediaAudio: true,
             calledGetUserMediaCombined: false,
@@ -60,6 +62,8 @@ describe('extractClientFeatures', () => {
             window: 'window',
             operatingSystem: undefined,
             webSocketConnectionTime: undefined,
+            audioDeviceUsbId: undefined,
+            videoDeviceUsbId: undefined,
             calledGetUserMedia: false,
             calledGetUserMediaAudio: false,
             calledGetUserMediaCombined: false,
@@ -139,6 +143,56 @@ describe('extractClientFeatures', () => {
         expect(features.audioShortDuration).to.be.true;
         expect(features.videoEnded).to.be.true;
         expect(features.videoShortDuration).to.be.undefined;
+    });
+
+    describe('device usb ids', () => {
+        const traceWithLabels = (...labels) => [
+            { type: 'create', value: { startTime: 1000 }, timestamp: 1000 },
+            {
+                type: 'navigator.mediaDevices.getUserMediaOnSuccess',
+                value: labels.map(([kind, label]) => [kind, kind + '-id', label, 'stream-id']),
+                timestamp: 1100
+            }
+        ];
+
+        it('should extract the usb id of the audio and video device', () => {
+            const features = extractClientFeatures(traceWithLabels(
+                ['audio', 'ACME mic (0000:0000)'],
+                ['video', 'ACME cam (0000:0000)']
+            ));
+
+            expect(features.audioDeviceUsbId).to.equal('0000:0000');
+            expect(features.videoDeviceUsbId).to.equal('0000:0000');
+        });
+
+        it('should be undefined for devices without a usb id', () => {
+            const features = extractClientFeatures(traceWithLabels(
+                ['audio', 'Default'],
+                ['video', 'fake_device_0']
+            ));
+
+            expect(features.audioDeviceUsbId).to.be.undefined;
+            expect(features.videoDeviceUsbId).to.be.undefined;
+        });
+
+        it('should not treat other parenthesized suffixes as a usb id', () => {
+            const features = extractClientFeatures(traceWithLabels(['audio', 'MacBook Pro Microphone (Built-in)']));
+
+            expect(features.audioDeviceUsbId).to.be.undefined;
+        });
+
+        it('should use the first device of that kind', () => {
+            const clientTrace = [
+                ...traceWithLabels(['audio', 'ACME mic (0000:0000)']),
+                {
+                    type: 'navigator.mediaDevices.getUserMediaOnSuccess',
+                    value: [['audio', 'audio-id-2', 'ACME other mic (1111:1111)', 'stream-id']],
+                    timestamp: 1200
+                }
+            ];
+
+            expect(extractClientFeatures(clientTrace).audioDeviceUsbId).to.equal('0000:0000');
+        });
     });
 
     describe('operatingSystem', () => {

--- a/supabase/migrations/20260802190000_add_device_usb_id_to_features_client.sql
+++ b/supabase/migrations/20260802190000_add_device_usb_id_to_features_client.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."features_client" ADD COLUMN audio_device_usb_id TEXT;
+ALTER TABLE "public"."features_client" ADD COLUMN video_device_usb_id TEXT;


### PR DESCRIPTION
Chromium appends the USB vendor:product id to the device label of USB audio and video devices, e.g. "Logitech BRIO (046d:085e)". Extract it from the first device of each kind reported by getUserMediaOnSuccess into the new audioDeviceUsbId and videoDeviceUsbId client features so issues can be correlated with the actual hardware in use.

The label is only treated as carrying an id when it ends in a closing parenthesis and the candidate substring has a colon in the middle, which keeps suffixes such as "MacBook Pro Microphone (Built-in)" from being mistaken for one.