### PR TITLE
shared: extract inbound tracks from transceiverModified

### DIFF
--- a/packages/rtcstats-shared/dump.js
+++ b/packages/rtcstats-shared/dump.js
@@ -355,6 +355,24 @@ export async function extractTracks(peerConnectionTrace) {
                     tracks.push(trackInformation);
                 }
             }
+        } else if (traceEvent.type === 'transceiverModified') {
+            // A transceiver created locally only starts receiving once the
+            // negotiation is done, which is the only signal for inbound tracks
+            // in dumps from Chrome versions without the ontrack event.
+            const {value} = traceEvent;
+            if (value.currentDirection?.includes('recv') && value.receiver?.track) {
+                const trackInformation = {
+                    startTime: traceEvent.timestamp,
+                    direction: 'inbound',
+                    kind: value.kind,
+                    id: value.receiver.track,
+                    label: value.receiver.track,
+                    streams: value.receiver.streams,
+                };
+                if (tracks.find(info => info.id === trackInformation.id) === undefined) {
+                    tracks.push(trackInformation);
+                }
+            }
         }
     }
     return tracks;

--- a/packages/rtcstats-shared/dump.js
+++ b/packages/rtcstats-shared/dump.js
@@ -277,7 +277,10 @@ export async function extractTracks(peerConnectionTrace) {
             const trackInformation = parseTrackWithStreams(traceEvent.value);
             trackInformation.startTime = traceEvent.timestamp;
             trackInformation.direction = 'inbound';
-            tracks.push(trackInformation);
+            if (tracks.find(info => info.direction === 'inbound' &&
+                    info.id === trackInformation.id) === undefined) {
+                tracks.push(trackInformation);
+            }
         } else if (traceEvent.type === 'addTransceiver') {
             if (typeof traceEvent.value[0] === 'string') {
                 // TODO: if we pass a kind here, how do we determine the track id?
@@ -348,7 +351,9 @@ export async function extractTracks(peerConnectionTrace) {
                     label: value.receiver.track,
                     streams: value.receiver.streams,
                 };
-                tracks.push(trackInformation);
+                if (tracks.find(info => info.id === trackInformation.id) === undefined) {
+                    tracks.push(trackInformation);
+                }
             }
         }
     }

--- a/packages/rtcstats-shared/test/dump.js
+++ b/packages/rtcstats-shared/test/dump.js
@@ -409,6 +409,64 @@ describe('RTCStats dump', () => {
                 streams: [ 'streamId' ],
             }]);
         });
+        it('deduplicates transceiverAdded after ontrack', async () => {
+            const blob = new Blob([
+                'RTCStatsDump\n',
+                JSON.stringify({fileFormat: 3}) + '\n',
+                JSON.stringify(['ontrack','1',['audio','trackId','remote audio','streamId'],1]) + '\n',
+                JSON.stringify(['transceiverAdded','1',{
+                    reason: 'setRemoteDescription',
+                    kind: 'audio',
+                    receiver: {
+                        track: 'trackId',
+                        streams: ['streamId'],
+                    },
+                },1]) + '\n',
+                JSON.stringify(['getStats','1',{
+                    7: {type:'inbound-rtp', trackIdentifier: 'trackId'},
+                },1]) + '\n',
+            ]);
+            const result = await readRTCStatsDump(blob);
+            const trackInfo = await extractTracks(result.peerConnections['1']);
+            expect(trackInfo).to.deep.equal([{
+                direction: 'inbound',
+                id: 'trackId',
+                kind: 'audio',
+                label: 'remote audio',
+                startTime: 1,
+                statsId: '7',
+                streams: [ 'streamId' ],
+            }]);
+        });
+        it('deduplicates ontrack after transceiverAdded', async () => {
+            const blob = new Blob([
+                'RTCStatsDump\n',
+                JSON.stringify({fileFormat: 3}) + '\n',
+                JSON.stringify(['transceiverAdded','1',{
+                    reason: 'setRemoteDescription',
+                    kind: 'audio',
+                    receiver: {
+                        track: 'trackId',
+                        streams: ['streamId'],
+                    },
+                },1]) + '\n',
+                JSON.stringify(['ontrack','1',['audio','trackId','remote audio','streamId'],1]) + '\n',
+                JSON.stringify(['getStats','1',{
+                    7: {type:'inbound-rtp', trackIdentifier: 'trackId'},
+                },1]) + '\n',
+            ]);
+            const result = await readRTCStatsDump(blob);
+            const trackInfo = await extractTracks(result.peerConnections['1']);
+            expect(trackInfo).to.deep.equal([{
+                direction: 'inbound',
+                id: 'trackId',
+                kind: 'audio',
+                label: 'trackId',
+                startTime: 1,
+                statsId: '7',
+                streams: [ 'streamId' ],
+            }]);
+        });
     });
 });
 

--- a/packages/rtcstats-shared/test/dump.js
+++ b/packages/rtcstats-shared/test/dump.js
@@ -409,6 +409,73 @@ describe('RTCStats dump', () => {
                 streams: [ 'streamId' ],
             }]);
         });
+        it('extracts from chromes transceiverModified once it receives', async () => {
+            const blob = new Blob(['RTCStatsDump\n',
+                JSON.stringify({fileFormat: 3}) + '\n',
+                JSON.stringify(['transceiverAdded','1',{
+                    reason: 'addTrack',
+                    kind: 'audio',
+                    sender: {
+                        track: 'localTrackId',
+                        streams: [],
+                    },
+                    receiver: {
+                        track: 'trackId',
+                        streams: [],
+                    },
+                    currentDirection: null,
+                },1]) + '\n',
+                JSON.stringify(['transceiverModified','1',{
+                    reason: 'setRemoteDescription',
+                    kind: 'audio',
+                    receiver: {
+                        track: 'trackId',
+                        streams: ['streamId'],
+                    },
+                    currentDirection: 'sendrecv',
+                },2]) + '\n',
+                JSON.stringify(['transceiverModified','1',{
+                    reason: 'setLocalDescription',
+                    kind: 'audio',
+                    receiver: {
+                        track: 'trackId',
+                        streams: ['streamId'],
+                    },
+                    currentDirection: 'sendrecv',
+                },3]) + '\n',
+                JSON.stringify(['getStats','1',{
+                    7: {type:'inbound-rtp', trackIdentifier: 'trackId'},
+                },4]) + '\n',
+            ]);
+            const result = await readRTCStatsDump(blob);
+            const trackInfo = await extractTracks(result.peerConnections['1']);
+            expect(trackInfo.filter(info => info.direction === 'inbound')).to.deep.equal([{
+                direction: 'inbound',
+                id: 'trackId',
+                kind: 'audio',
+                label: 'trackId',
+                startTime: 3,
+                statsId: '7',
+                streams: [ 'streamId' ],
+            }]);
+        });
+        it('ignores chromes transceiverModified while it does not receive', async () => {
+            const blob = new Blob(['RTCStatsDump\n',
+                JSON.stringify({fileFormat: 3}) + '\n',
+                JSON.stringify(['transceiverModified','1',{
+                    reason: 'setRemoteDescription',
+                    kind: 'audio',
+                    receiver: {
+                        track: 'trackId',
+                        streams: [],
+                    },
+                    currentDirection: 'sendonly',
+                },1]) + '\n',
+            ]);
+            const result = await readRTCStatsDump(blob);
+            const trackInfo = await extractTracks(result.peerConnections['1']);
+            expect(trackInfo).to.deep.equal([]);
+        });
         it('deduplicates transceiverAdded after ontrack', async () => {
             const blob = new Blob([
                 'RTCStatsDump\n',


### PR DESCRIPTION
a transceiver created locally by addTrack only starts receiving after
negotiation, which chrome://webrtc-internals signals with
transceiverModified. Without it the inbound tracks of such a connection
are not extracted at all in dumps from Chrome versions predating ontrack.