### PR TITLE
shared: uncompress gzipped dumps in readDump

### DIFF
--- a/dump-importer/anonymize.js
+++ b/dump-importer/anonymize.js
@@ -1,4 +1,5 @@
 import {anonymizeBlob} from '../packages/rtcstats-shared/anonymize.js';
+import {maybeUncompressDump} from '@rtcstats/rtcstats-shared';
 
 const area = document.getElementById('upload-area');
 const fileInput = document.getElementById('import');
@@ -32,13 +33,7 @@ document.getElementById('import').onchange = async (evt) => {
 
     const files = evt.target.files;
     const file = files[0];
-    let stream;
-    if (['application/gzip', 'application/x-gzip'].includes(file.type)) {
-        stream = file.stream().pipeThrough(new DecompressionStream('gzip'));
-    } else {
-        stream = file.stream();
-    }
-    const blob = await (new Response(stream)).blob();
+    const blob = await maybeUncompressDump(file);
     const newBlob = await anonymizeBlob(await blob.text());
     if (newBlob) {
         const anchor = document.getElementById('download');

--- a/dump-importer/main.js
+++ b/dump-importer/main.js
@@ -1,6 +1,6 @@
 import {RTCStatsDumpImporter} from './import-rtcstats.js';
 import {WebRTCInternalsDumpImporter} from './import-internals.js';
-import {detectRTCStatsDump, detectWebRTCInternalsDump} from '@rtcstats/rtcstats-shared';
+import {detectRTCStatsDump, detectWebRTCInternalsDump, maybeUncompressDump} from '@rtcstats/rtcstats-shared';
 
 const container = document.getElementById('tables');
 document.getElementById('import').onchange = async (evt) => {
@@ -15,13 +15,7 @@ document.getElementById('import').onchange = async (evt) => {
     const status = document.getElementById('status');
     status.textContent = file.name;
     status.classList.add('visible');
-    let stream;
-    if (['application/gzip', 'application/x-gzip'].includes(file.type)) {
-        stream = file.stream().pipeThrough(new DecompressionStream('gzip'));
-    } else {
-        stream = file.stream();
-    }
-    const blob = await (new Response(stream)).blob();
+    const blob = await maybeUncompressDump(file);
     if (await detectRTCStatsDump(blob)) {
         window.importer = new RTCStatsDumpImporter(container);
         importer.process(blob);

--- a/packages/rtcstats-shared/dump.js
+++ b/packages/rtcstats-shared/dump.js
@@ -41,13 +41,22 @@ const STATE_VALUES = {
     },
 };
 
+// Call before format detection, dumps are frequently stored gzipped.
+export async function maybeUncompressDump(blob) {
+    const magic = new Uint8Array(await blob.slice(0, 2).arrayBuffer());
+    if (magic[0] !== 0x1f || magic[1] !== 0x8b) {
+        return blob;
+    }
+    return new Response(blob.stream().pipeThrough(new DecompressionStream('gzip'))).blob();
+}
+
 export async function detectRTCStatsDump(blob) {
     const magic = await blob.slice(0, 13).text();
     return magic.startsWith('RTCStatsDump\n');
 }
 
 export async function detectWebRTCInternalsDump(blob) {
-    return (await blob.text()).startsWith('{');
+    return (await blob.slice(0, 1).text()) === '{';
 }
 
 export async function readRTCStatsDump(blob) {
@@ -257,12 +266,16 @@ export function internalsToRtcstats(data) {
     return {peerConnections, eventSizes: {}};
 }
 
-// Auto-detect the dump format and dispatch.
+// Uncompress if needed, auto-detect the dump format and dispatch.
 export async function readDump(blob) {
-    if (await detectRTCStatsDump(blob)) {
-        return readRTCStatsDump(blob);
+    const dump = await maybeUncompressDump(blob);
+    if (await detectRTCStatsDump(dump)) {
+        return readRTCStatsDump(dump);
     }
-    return internalsToRtcstats(await readWebRTCInternalsDump(blob));
+    if (!await detectWebRTCInternalsDump(dump)) {
+        throw new Error('Unrecognized dump format');
+    }
+    return internalsToRtcstats(await readWebRTCInternalsDump(dump));
 }
 
 export async function extractTracks(peerConnectionTrace) {

--- a/packages/rtcstats-shared/index.d.ts
+++ b/packages/rtcstats-shared/index.d.ts
@@ -1,5 +1,6 @@
 // Type definitions for @rtcstats/rtcstats-shared
 
+export async function maybeUncompressDump(blob: Blob): Promise<Blob>;
 export async function detectWebRTCInternalsDump(blob: Blob): Promise<boolean>;
 export async function readWebRTCInternalsDump(blob: Blob): Promise<object>;
 export async function detectRTCStatsDump(blob: Blob): Promise<boolean>;

--- a/packages/rtcstats-shared/test/dump.js
+++ b/packages/rtcstats-shared/test/dump.js
@@ -2,6 +2,7 @@ import {
     detectRTCStatsDump,
     detectWebRTCInternalsDump,
     internalsToRtcstats,
+    maybeUncompressDump,
     readDump,
     readRTCStatsDump,
     readWebRTCInternalsDump,
@@ -510,6 +511,40 @@ describe('webrtc-internals dump', () => {
             expect(Object.keys(result.peerConnections)).to.have.members(['null', '23-3']);
             expect(result.peerConnections['23-3'][0].type).to.equal('create');
             expect(result.peerConnections['23-3'][0].timestamp).to.equal(1778229287516);
+        });
+
+        it('reads a gzipped dump', async () => {
+            const blob = new Blob(['RTCStatsDump\n' +
+                JSON.stringify({fileFormat: 3}) + '\n' +
+                JSON.stringify(['close', null, 1001, 1]) + '\n']);
+            const gzipped = await new Response(blob.stream()
+                .pipeThrough(new CompressionStream('gzip'))).blob();
+            const result = await readDump(gzipped);
+            expect(result.fileFormat).to.equal(3);
+            expect(result.peerConnections['null'][0].type).to.equal('close');
+        });
+
+        it('rejects an unrecognized format', async () => {
+            let error;
+            try {
+                await readDump(new Blob(['not a dump']));
+            } catch (err) {
+                error = err;
+            }
+            expect(error).to.be.an('error');
+        });
+    });
+
+    describe('maybeUncompressDump', () => {
+        it('returns an uncompressed blob unchanged', async () => {
+            const blob = new Blob(['RTCStatsDump\n']);
+            expect(await maybeUncompressDump(blob)).to.equal(blob);
+        });
+
+        it('uncompresses a gzipped blob', async () => {
+            const gzipped = await new Response(new Blob(['RTCStatsDump\n']).stream()
+                .pipeThrough(new CompressionStream('gzip'))).blob();
+            expect(await (await maybeUncompressDump(gzipped)).text()).to.equal('RTCStatsDump\n');
         });
     });
 });


### PR DESCRIPTION
Adds maybeUncompressDump for callers that need the detected format and use the format specific readers, like the dump-importer.