### PR TITLE
features: add timeToFirstFrame to track features

### DIFF
--- a/packages/rtcstats-features/features.md
+++ b/packages/rtcstats-features/features.md
@@ -296,6 +296,7 @@ Track features describe a single inbound or outbound media track. The extractor 
 | `trackIdentifier` | string | trackInformation | The track's `id`. |
 | `startTime` | number | trackInformation | Timestamp at which the track was added to the connection. |
 | `hasNullVideoDecoder` | boolean | aggregated getStats | Whether the null video decoder was used at any point (`decoderImplementation === 'NullVideoDecoder'`). Inbound video only; otherwise `undefined`. |
+| `timeToFirstFrame` | number | time delta | Milliseconds between the `ontrack` event and the track's first `unmute` event. Inbound only. |
 
 ### Codec
 

--- a/packages/rtcstats-features/features/track.js
+++ b/packages/rtcstats-features/features/track.js
@@ -36,6 +36,19 @@ function hasNullVideoDecoder(peerConnectionTrace, trackInformation) {
     return false;
 }
 
+function timeToFirstFrame(peerConnectionTrace, trackInformation) {
+    if (trackInformation.direction !== 'inbound') {
+        return undefined;
+    }
+    for (const traceEvent of peerConnectionTrace) {
+        if (traceEvent.type !== 'MediaStreamTrack.onunmute') continue;
+        if (traceEvent.value !== trackInformation.id) continue;
+        const delta = Math.floor(traceEvent.timestamp - trackInformation.startTime);
+        return delta >= 0 ? delta : undefined;
+    }
+    return undefined;
+}
+
 function resolutionFeatures(/* clientTrace*/_, peerConnectionTrace, trackInformation) {
     if (trackInformation.kind === 'audio') return {};
     const widths = {};
@@ -210,11 +223,12 @@ export function extractTrackFeatures(/* clientTrace*/_, peerConnectionTrace, tra
     // getStats events which are associated with trackInformation.statsId.
     const features = {
         direction: trackInformation.direction,
+        hasNullVideoDecoder: hasNullVideoDecoder(peerConnectionTrace, trackInformation),
         kind: trackInformation.kind,
         startTime: trackInformation.startTime,
+        timeToFirstFrame: timeToFirstFrame(peerConnectionTrace, trackInformation),
         trackIdentifier: trackInformation.id,
     };
-    features.hasNullVideoDecoder = hasNullVideoDecoder(peerConnectionTrace, trackInformation);
 
     return {
         ...codecFeatures(undefined, peerConnectionTrace, trackInformation),

--- a/packages/rtcstats-features/test/track.js
+++ b/packages/rtcstats-features/test/track.js
@@ -475,4 +475,69 @@ describe('extractTrackFeatures', () => {
             expect(features.hasPeriodicJitterBufferFlushes).to.equal(false);
         });
     });
+
+    describe('timeToFirstFrame', () => {
+        const trackInfo = {
+            direction: 'inbound',
+            id: 'track1',
+            kind: 'video',
+            startTime: 1000,
+            statsId: 'track1_stats',
+        };
+
+        it('should extract the delta between ontrack and the unmute event', () => {
+            const pcTrace = [
+                {timestamp: 2200, type: 'MediaStreamTrack.onunmute', value: 'track1'},
+            ];
+            const features = extractTrackFeatures([], pcTrace, trackInfo);
+            expect(features.timeToFirstFrame).to.equal(1200);
+        });
+
+        it('should return undefined if there is no unmute event', () => {
+            const features = extractTrackFeatures([], [], trackInfo);
+            expect(features.timeToFirstFrame).to.be.undefined;
+        });
+
+        it('should return undefined for outbound tracks', () => {
+            const outboundTrackInfo = {
+                direction: 'outbound',
+                id: 'track1',
+                kind: 'video',
+                startTime: 1000,
+                statsId: 'track1_stats',
+            };
+            const pcTrace = [
+                {timestamp: 2200, type: 'MediaStreamTrack.onunmute', value: 'track1'},
+            ];
+            const features = extractTrackFeatures([], pcTrace, outboundTrackInfo);
+            expect(features.timeToFirstFrame).to.be.undefined;
+        });
+
+        it('should ignore unmute events for other tracks', () => {
+            const pcTrace = [
+                {timestamp: 2200, type: 'MediaStreamTrack.onunmute', value: 'track2'},
+            ];
+            const features = extractTrackFeatures([], pcTrace, trackInfo);
+            expect(features.timeToFirstFrame).to.be.undefined;
+        });
+
+        it('should use the first unmute event when the track mutes and unmutes again', () => {
+            const pcTrace = [
+                {timestamp: 2200, type: 'MediaStreamTrack.onunmute', value: 'track1'},
+                {timestamp: 3000, type: 'MediaStreamTrack.onmute', value: 'track1'},
+                {timestamp: 4000, type: 'MediaStreamTrack.onunmute', value: 'track1'},
+                {timestamp: 5000, type: 'MediaStreamTrack.onmute', value: 'track1'},
+            ];
+            const features = extractTrackFeatures([], pcTrace, trackInfo);
+            expect(features.timeToFirstFrame).to.equal(1200);
+        });
+
+        it('should return undefined if the unmute event predates the track', () => {
+            const pcTrace = [
+                {timestamp: 900, type: 'MediaStreamTrack.onunmute', value: 'track1'},
+            ];
+            const features = extractTrackFeatures([], pcTrace, trackInfo);
+            expect(features.timeToFirstFrame).to.be.undefined;
+        });
+    });
 });

--- a/supabase/migrations/20260810100000_add_time_to_first_frame_to_features_track.sql
+++ b/supabase/migrations/20260810100000_add_time_to_first_frame_to_features_track.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."features_track" ADD COLUMN time_to_first_frame INTEGER;


### PR DESCRIPTION
Measures the delta between the ontrack event and the track's first MediaStreamTrack.onunmute, i.e. how long an inbound track waited before carrying media.

Averaging over this is problematic: for tracks negotiated in the initial offer/answer the delta happens before the connection is up and hence includes ICE and DTLS, while tracks added to an established connection do not pay that cost. The two populations are not comparable, subtract features_connection.connection_time or split them before aggregating.