### PR TITLE
server: strip rtcstats-token from url

### DIFF
--- a/dump-importer/import-common.js
+++ b/dump-importer/import-common.js
@@ -104,23 +104,6 @@ export function createContainers(connid, url, containers) {
     const summary = document.createElement('summary');
     summary.innerText = 'Connection:' + connid + ' URL: ' + url;
     container.appendChild(summary);
-    if (url) {
-        const parsedUrl = new URL(url);
-        if (parsedUrl && parsedUrl.searchParams.has('rtcstats-token')) { // Parse JWT by hand.
-            const parts = parsedUrl.searchParams.get('rtcstats-token').split('.');
-            if (parts[1]) {
-                const rawJwt = atob(parts[1]);
-                if (rawJwt) {
-                    const parsedJwt = JSON.parse(rawJwt);
-                    if (parsedJwt.rtcStats) {
-                        const rtcstatsToken = document.createElement('div');
-                        rtcstatsToken.innerText = 'Decoded RTCStats token: ' + JSON.stringify(parsedJwt.rtcStats, null, ' ');
-                        container.appendChild(rtcstatsToken);
-                    }
-                }
-            }
-        }
-    }
 
     const configuration = document.createElement('div');
     container.appendChild(configuration);

--- a/packages/rtcstats-server/rtcstats-websocket.js
+++ b/packages/rtcstats-server/rtcstats-websocket.js
@@ -1,8 +1,13 @@
 import {obfuscateIpOrAddress} from '@rtcstats/rtcstats-shared/address-obfuscator.js';
 
 export async function extractMetadata(upgradeRequest, options = {}) {
-    // The url the client is coming from
-    const url = upgradeRequest.url;
+    // The url the client is coming from. rtcstats-token has already
+    // been validated if present and is removed.
+    const requestUrl = new URL(upgradeRequest.url, 'http://localhost');
+    if (requestUrl.searchParams.has('rtcstats-token')) {
+        requestUrl.searchParams.set('rtcstats-token', 'obfuscated');
+    }
+    const url = requestUrl.pathname + requestUrl.search;
     // TODO: check origin against known/valid urls?
     const {origin} = upgradeRequest.headers;
 


### PR DESCRIPTION
while that is ok-ish to include in local dumps (in particular with a short expiration time), it should not be uploaded to entities like rtcstats.com

Fixes #324