### PR TITLE
features: add statsTruncated to connection features

### DIFF
--- a/packages/rtcstats-features/features.md
+++ b/packages/rtcstats-features/features.md
@@ -159,6 +159,7 @@ handful come from periodic [`getStats`](https://w3c.github.io/webrtc-pc/#dom-rtc
 | `numberOfNegotiations` | number | count | Number of signaling state changes to `stable`, i.e. completed negotiations including rollbacks. |
 | `pendingNegotiationAtEnd` | boolean | last signaling state | Whether the connection ended mid-negotiation, i.e. the last signaling state before closing was not `stable`. |
 | `signalingDelay` | number | time delta | First offer/answer round-trip time, from `setLocalDescription({type:'offer'})` to the first subsequent `setRemoteDescription({type:'answer'})`. |
+| `statsTruncated` | boolean | aggregated getStats | Whether the beginning of the `getStats` timeseries is missing because chrome://webrtc-internals only keeps 1000 samples per stats property. |
 | `clockSkew` | number | first getStats | Skew (ms) between the first `getStats` call time (`Date.now()`) and the `peer-connection` stats timestamp in that report. Large when the page was open across an OS suspend. |
 
 ### API failures

--- a/packages/rtcstats-features/features/connection.js
+++ b/packages/rtcstats-features/features/connection.js
@@ -520,6 +520,26 @@ function signalingDelay(/* clientTrace*/_, peerConnectionTrace) {
     return peerConnectionTrace[second].timestamp - peerConnectionTrace[first].timestamp;
 }
 
+function statsTruncated(/* clientTrace*/_, peerConnectionTrace) {
+    // chrome://webrtc-internals only keeps the last 1000 samples per stats property.
+    const firstSeen = {};
+    const samples = {};
+    for (const traceEvent of peerConnectionTrace) {
+        if (traceEvent.type !== 'getStats' || !traceEvent.value) {
+            continue;
+        }
+        Object.keys(traceEvent.value).forEach(id => {
+            if (samples[id] === undefined) {
+                firstSeen[id] = traceEvent.timestamp;
+                samples[id] = 0;
+            }
+            samples[id]++;
+        });
+    }
+    return Object.keys(samples).some(id => samples[id] === 1000 &&
+        firstSeen[id] - peerConnectionTrace[0].timestamp > 60000);
+}
+
 export function extractConnectionFeatures(/* clientTrace*/_, peerConnectionTrace) {
     // A trace will always have at least one event.
     return {
@@ -545,5 +565,6 @@ export function extractConnectionFeatures(/* clientTrace*/_, peerConnectionTrace
         signalingDelay: signalingDelay(undefined, peerConnectionTrace),
         // The timestamp at which the peer connection was created.
         startTime: peerConnectionTrace[0].timestamp,
+        statsTruncated: statsTruncated(undefined, peerConnectionTrace),
     };
 }

--- a/packages/rtcstats-features/test/connection.js
+++ b/packages/rtcstats-features/test/connection.js
@@ -33,6 +33,7 @@ describe('extractConnectionFeatures', () => {
             numberOfEventsNotGetStats: 2,
             numberOfNegotiations: 0,
             startTime: 1000,
+            statsTruncated: false,
             usingIceLite: false,
         });
     });
@@ -843,6 +844,51 @@ describe('extractConnectionFeatures', () => {
             const features = extractConnectionFeatures([], pcTrace);
             expect(features.numberOfNegotiations).to.equal(0);
             expect(features.pendingNegotiationAtEnd).to.equal(undefined);
+        });
+    });
+
+    describe('statsTruncated', () => {
+        function getStatsEvents(count, startTime) {
+            return new Array(count).fill().map((_, index) => ({
+                type: 'getStats',
+                value: {OT1: {id: 'OT1', type: 'outbound-rtp'}},
+                timestamp: startTime + index * 1000,
+            }));
+        }
+
+        it('is true when a stat sits at the 1000 sample cap long after the connection was created', () => {
+            const pcTrace = [
+                { type: 'create', timestamp: 1000 },
+                ...getStatsEvents(1000, 600000),
+            ];
+            const features = extractConnectionFeatures([], pcTrace);
+            expect(features.statsTruncated).to.equal(true);
+        });
+
+        it('is false when a stat sits at the 1000 sample cap since the connection was created', () => {
+            const pcTrace = [
+                { type: 'create', timestamp: 1000 },
+                ...getStatsEvents(1000, 2000),
+            ];
+            const features = extractConnectionFeatures([], pcTrace);
+            expect(features.statsTruncated).to.equal(false);
+        });
+
+        it('is false below the 1000 sample cap', () => {
+            const pcTrace = [
+                { type: 'create', timestamp: 1000 },
+                ...getStatsEvents(999, 600000),
+            ];
+            const features = extractConnectionFeatures([], pcTrace);
+            expect(features.statsTruncated).to.equal(false);
+        });
+
+        it('is false without getStats', () => {
+            const pcTrace = [
+                { type: 'create', timestamp: 1000 },
+            ];
+            const features = extractConnectionFeatures([], pcTrace);
+            expect(features.statsTruncated).to.equal(false);
         });
     });
 });

--- a/supabase/migrations/20260814100000_add_stats_truncated_to_features_connection.sql
+++ b/supabase/migrations/20260814100000_add_stats_truncated_to_features_connection.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."features_connection" ADD COLUMN stats_truncated BOOLEAN;


### PR DESCRIPTION
chrome://webrtc-internals keeps at most 1000 samples per stats property so long connections lose the beginning of their getStats timeseries.