### PR TITLE
features: add TURN gathering times to connection features

### DIFF
--- a/packages/rtcstats-features/features.md
+++ b/packages/rtcstats-features/features.md
@@ -236,6 +236,18 @@ All fields are derived from the [`RTCConfiguration`](https://w3c.github.io/webrt
 | `gatheredSrflxCandidate` | boolean | presence | A `srflx` candidate was gathered locally. |
 | `gatheredTurnCandidate` | boolean | presence | A `relay` candidate was gathered locally. |
 
+### TURN gathering times
+
+Time between [`icegatheringstatechange`](https://w3c.github.io/webrtc-pc/#event-icegatheringstatechange) becoming `gathering` and the first local `relay` candidate allocated over the respective TURN transport. The transport comes from [`relayProtocol`](https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-relayprotocol) which `rtcstats-js` serializes on the `onicecandidate` event. Only the first gathering phase is measured: the window opens on `gathering` and ends for good on `complete`, so candidates gathered after an ICE restart do not contribute.
+
+Note that a missing value does not necessarily mean the TURN server was unreachable: gathering stops once the connection is established, so a call that connects on a host pair within a few milliseconds completes gathering before any relay candidate is allocated.
+
+| Feature | Type | Source | Description |
+| --- | --- | --- | --- |
+| `gatheringTimeTurnUdp` | number | time delta | Milliseconds until the first candidate relayed over TURN/UDP. |
+| `gatheringTimeTurnTcp` | number | time delta | Milliseconds until the first candidate relayed over TURN/TCP. |
+| `gatheringTimeTurnTls` | number | time delta | Milliseconds until the first candidate relayed over TURN/TLS. |
+
 ### First selected candidate pair
 
 All fields below come from the first `getStats` report taken after `onconnectionstatechange='connected'` whose [`transport`](https://w3c.github.io/webrtc-stats/#transportstats-dict*) has a [`selectedCandidatePairId`](https://w3c.github.io/webrtc-stats/#dom-rtctransportstats-selectedcandidatepairid). Local and remote [`RTCIceCandidateStats`](https://w3c.github.io/webrtc-stats/#icecandidate-dict*) are looked up by id from the same report. Absent if no such report exists.

--- a/packages/rtcstats-features/features/connection.js
+++ b/packages/rtcstats-features/features/connection.js
@@ -25,7 +25,39 @@ function getSelectedCandidatePairStats(report) {
 }
 
 function iceFeatures(/* clientTrace */_, peerConnectionTrace) {
+    const turnGatheringTimes = (() => {
+        // Time (in milliseconds) between icegatheringstate becoming 'gathering' and the first
+        // relay candidate gathered from a TURN server using the respective transport.
+        // Requires the relayProtocol serialized by rtcstats-js.
+        // Only the first gathering phase is measured.
+        const featureNames = {
+            tcp: 'gatheringTimeTurnTcp',
+            tls: 'gatheringTimeTurnTls',
+            udp: 'gatheringTimeTurnUdp',
+        };
+        const times = {};
+        let gatheringStart = 0;
+        for (const traceEvent of peerConnectionTrace) {
+            if (traceEvent.type === 'onicegatheringstatechange') {
+                if (traceEvent.value === 'gathering') {
+                    gatheringStart = traceEvent.timestamp;
+                    continue;
+                } else if (traceEvent.value === 'complete') {
+                    // Gathering stops once the connection is established, which shows up as
+                    // 'complete', so the window ends there.
+                    break;
+                }
+            }
+            if (!gatheringStart || traceEvent.type !== 'onicecandidate') continue;
+            const name = featureNames[traceEvent.value?.relayProtocol];
+            if (name && times[name] === undefined) {
+                times[name] = traceEvent.timestamp - gatheringStart;
+            }
+        }
+        return times;
+    })();
     return {
+        ...turnGatheringTimes,
         iceConnected: peerConnectionTrace.find(traceEvent => {
             // Whether the ice connection was established.
             return traceEvent.type === 'oniceconnectionstatechange' && traceEvent.value === 'connected';

--- a/packages/rtcstats-features/test/connection.js
+++ b/packages/rtcstats-features/test/connection.js
@@ -891,4 +891,94 @@ describe('extractConnectionFeatures', () => {
             expect(features.statsTruncated).to.equal(false);
         });
     });
+
+    describe('TURN gathering times', () => {
+        function relayCandidate(relayProtocol, timestamp) {
+            return {
+                type: 'onicecandidate',
+                value: {
+                    candidate: 'candidate:1 1 udp 41885439 1.2.3.4 9000 typ relay raddr 0.0.0.0 rport 0',
+                    relayProtocol,
+                },
+                timestamp,
+            };
+        }
+
+        it('measures the time from gathering to the first candidate per relay protocol', () => {
+            const pcTrace = [
+                { type: 'create', timestamp: 1000 },
+                { type: 'onicegatheringstatechange', value: 'gathering', timestamp: 1100 },
+                relayCandidate('udp', 1150),
+                relayCandidate('tcp', 1300),
+                relayCandidate('tls', 1600),
+            ];
+            const features = extractConnectionFeatures([], pcTrace);
+            expect(features.gatheringTimeTurnUdp).to.equal(50);
+            expect(features.gatheringTimeTurnTcp).to.equal(200);
+            expect(features.gatheringTimeTurnTls).to.equal(500);
+        });
+
+        it('uses the first candidate of each relay protocol', () => {
+            const pcTrace = [
+                { type: 'onicegatheringstatechange', value: 'gathering', timestamp: 1000 },
+                relayCandidate('udp', 1100),
+                relayCandidate('udp', 1200),
+            ];
+            const features = extractConnectionFeatures([], pcTrace);
+            expect(features.gatheringTimeTurnUdp).to.equal(100);
+        });
+
+        it('only measures the first gathering phase', () => {
+            const pcTrace = [
+                { type: 'onicegatheringstatechange', value: 'gathering', timestamp: 1000 },
+                relayCandidate('udp', 1100),
+                { type: 'onicegatheringstatechange', value: 'complete', timestamp: 1200 },
+                { type: 'onicegatheringstatechange', value: 'gathering', timestamp: 2000 },
+                relayCandidate('tcp', 2100),
+            ];
+            const features = extractConnectionFeatures([], pcTrace);
+            expect(features.gatheringTimeTurnUdp).to.equal(100);
+            expect(features.gatheringTimeTurnTcp).to.be.undefined;
+        });
+
+        it('is undefined for relay protocols that were not gathered', () => {
+            const pcTrace = [
+                { type: 'onicegatheringstatechange', value: 'gathering', timestamp: 1000 },
+                relayCandidate('udp', 1100),
+            ];
+            const features = extractConnectionFeatures([], pcTrace);
+            expect(features.gatheringTimeTurnTcp).to.be.undefined;
+            expect(features.gatheringTimeTurnTls).to.be.undefined;
+        });
+
+        it('ignores candidates after gathering completed', () => {
+            const pcTrace = [
+                { type: 'onicegatheringstatechange', value: 'gathering', timestamp: 1000 },
+                { type: 'onicegatheringstatechange', value: 'complete', timestamp: 1050 },
+                relayCandidate('udp', 5000),
+            ];
+            const features = extractConnectionFeatures([], pcTrace);
+            expect(features.gatheringTimeTurnUdp).to.be.undefined;
+        });
+
+        it('is undefined without a gathering state change', () => {
+            const pcTrace = [
+                relayCandidate('udp', 1100),
+            ];
+            const features = extractConnectionFeatures([], pcTrace);
+            expect(features.gatheringTimeTurnUdp).to.be.undefined;
+        });
+
+        it('is undefined for candidates without a relay protocol', () => {
+            const pcTrace = [
+                { type: 'onicegatheringstatechange', value: 'gathering', timestamp: 1000 },
+                { type: 'onicecandidate', value: { candidate: 'candidate:1 1 udp 2122260223 192.168.1.2 9000 typ host' }, timestamp: 1100 },
+                { type: 'onicecandidate', value: null, timestamp: 1200 },
+            ];
+            const features = extractConnectionFeatures([], pcTrace);
+            expect(features.gatheringTimeTurnUdp).to.be.undefined;
+            expect(features.gatheringTimeTurnTcp).to.be.undefined;
+            expect(features.gatheringTimeTurnTls).to.be.undefined;
+        });
+    });
 });

--- a/supabase/migrations/20260816100000_add_turn_gathering_times_to_features_connection.sql
+++ b/supabase/migrations/20260816100000_add_turn_gathering_times_to_features_connection.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."features_connection" ADD COLUMN gathering_time_turn_udp INTEGER;
+ALTER TABLE "public"."features_connection" ADD COLUMN gathering_time_turn_tcp INTEGER;
+ALTER TABLE "public"."features_connection" ADD COLUMN gathering_time_turn_tls INTEGER;


### PR DESCRIPTION
Measure the time between icegatheringstate becoming 'gathering' and the first relay candidate allocated over TURN/UDP, TURN/TCP and TURN/TLS, i.e. the allocate round trip to the TURN server.

The transport comes from the relayProtocol that rtcstats-js serializes onto the onicecandidate event, which avoids the priority->type table the gatheredTurnCandidate TODO warns about.

Only the first gathering phase is measured: gathering stops once the connection is established, so the window ends on 'complete'.