### PR TITLE
server: fix and harden the Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,7 @@ packages/rtcstats-js/browsers/
 
 packages/rtcstats-shared/node_modules/
 packages/rtcstats-shared/test/
+
+packages/rtcstats-node-shared/node_modules/
+packages/rtcstats-node-shared/coverage/
+packages/rtcstats-node-shared/test/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,36 @@
 # docker build -t rtcstats-server -f Dockerfile .
 # docker run -p 8080:8080 rtcstats-server
-# See also: https://www.docker.com/blog/getting-started-with-docker-using-node-jspart-i/
 # Configuration can be passed via environment variables, e.g.
 # docker run -p 8080:8071 -e NODE_CONFIG='{"server": {"httpPort":8071}}' rtcstats-server
 FROM node:22-alpine
 
+# tini as PID 1 so SIGTERM reaches node and `docker stop` shuts down promptly.
+RUN apk add --no-cache tini
+
 WORKDIR /server
-COPY package.json .
 
-# Copy shared and server / packages.
-WORKDIR /server/packages/rtcstats-shared
-COPY packages/rtcstats-shared .
+COPY package.json ./
+COPY packages/rtcstats-shared/package.json packages/rtcstats-shared/
+COPY packages/rtcstats-node-shared/package.json packages/rtcstats-node-shared/
+COPY packages/rtcstats-server/package.json packages/rtcstats-server/
 
+RUN npm install --omit=dev \
+    --workspace=packages/rtcstats-server \
+    --include-workspace-root
+
+COPY packages/rtcstats-shared packages/rtcstats-shared
+COPY packages/rtcstats-node-shared packages/rtcstats-node-shared
+COPY packages/rtcstats-server packages/rtcstats-server
+# Default config only; deploy-time config is injected via NODE_CONFIG or a mount.
+COPY config/default.yaml config/default.yaml
+
+RUN chown -R node:node /server
+USER node
+
+EXPOSE 8080
 WORKDIR /server/packages/rtcstats-server
-COPY packages/rtcstats-server .
-
-WORKDIR /server
-# Install once to seed. Starting will install again!
-RUN npm install
-
-# TODO: download supabase crt
-# https://supabase-downloads.s3-ap-southeast-1.amazonaws.com/prod/ssl/prod-ca-2021.crt
-
-ENTRYPOINT ["npm"]
-# start MUST run npm install again to refresh the symbolic links
-CMD ["start", "--workspace=packages/rtcstats-server"]
+ENV NODE_CONFIG_DIR=/server/config
+HEALTHCHECK --interval=30s --timeout=3s \
+    CMD wget -qO- http://localhost:8080/healthcheck || exit 1
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "app.js"]

--- a/packages/rtcstats-server/package.json
+++ b/packages/rtcstats-server/package.json
@@ -16,6 +16,7 @@
     "@rtcstats/rtcstats-shared": "*",
     "config": "^4.1.1",
     "globals": "^16.2.0",
+    "js-yaml": "^4.1.0",
     "maxmind": "^5.0.0",
     "uuid": "^11.1.0",
     "ws": "^8.18.3"


### PR DESCRIPTION
The image predated the rtcstats-node-shared split and never ran: it did not copy that workspace (server crashed on import) and never copied the config directory (NODE_CONFIG_DIR pointed at a missing dir).

- Copy rtcstats-node-shared and config/default.yaml (default only; deploy injects real config via NODE_CONFIG or a mount, so secrets and env configs are never baked in).
- Declare js-yaml as a server dependency. node-config loads it at runtime to parse the YAML configs; it was only present transitively via eslint/mocha devDependencies, so an --omit=dev install had no YAML parser and silently loaded empty config.
- Install with --omit=dev scoped to the server workspace; drop the runtime "npm i" (build-time install already wires the workspace symlinks correctly).
- Run as the non-root node user.
- tini as PID 1 so SIGTERM reaches node and docker stop is prompt (~150ms instead of the 10s SIGKILL wait).
- Add EXPOSE and a HEALTHCHECK against /healthcheck.